### PR TITLE
实现了更符合 MD3 的过渡动画

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/deploymentTargetDropDown.xml
+/.idea/deploymentTargetSelector.xml
+/.idea/migrations.xml
+/.idea/runConfigurations.xml
 .DS_Store
 /build
 /captures

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17">
+    <bytecodeTargetLevel target="21">
       <module name="BIT101.buildSrc" target="17" />
       <module name="BIT101.buildSrc.main" target="17" />
       <module name="BIT101.buildSrc.test" target="17" />

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,10 +1,34 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
             versionCode: 4,
             versionName: '1.2.0',
 
-            jvmTarget: '17',
-            sourceCompatibility: JavaVersion.VERSION_17,
-            targetCompatibility: JavaVersion.VERSION_17,
+            jvmTarget: '21',
+            sourceCompatibility: JavaVersion.VERSION_21,
+            targetCompatibility: JavaVersion.VERSION_21,
             kotlinCompilerExtensionVersion: '1.5.8',
 
             hilt: '2.48'
@@ -27,8 +27,8 @@ buildscript {
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.2' apply false
-    id 'com.android.library' version '8.1.2' apply false
+    id 'com.android.application' version '8.8.0' apply false
+    id 'com.android.library' version '8.8.0' apply false
     id "com.google.dagger.hilt.android" version "2.48" apply false
     id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.9.22' apply false

--- a/features/common/src/main/java/cn/bit101/android/features/common/motion/MaterialSharedAxis.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/motion/MaterialSharedAxis.kt
@@ -20,12 +20,15 @@ import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
@@ -173,5 +176,39 @@ public fun materialSharedAxisYOut(
         durationMillis = durationMillis.ForOutgoing,
         delayMillis = 0,
         easing = FastOutLinearInEasing
+    )
+)
+
+public fun materialSharedAxisZIn(
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+    easing: Easing = MotionConstants.EmphasizedDecelerate,
+): EnterTransition = scaleIn(
+    initialScale = 0.8f,
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = easing,
+    )
+) + fadeIn(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForIncoming,
+        delayMillis = durationMillis.ForOutgoing,
+        easing = easing
+    )
+)
+
+public fun materialSharedAxisZOut(
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+    easing: Easing = MotionConstants.EmphasizedAccelerate,
+): ExitTransition = scaleOut(
+    targetScale = 1.2f,
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = easing,
+    )
+) + fadeOut(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForOutgoing,
+        delayMillis = 0,
+        easing = easing
     )
 )

--- a/features/common/src/main/java/cn/bit101/android/features/common/motion/MaterialSharedAxis.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/motion/MaterialSharedAxis.kt
@@ -1,0 +1,177 @@
+package cn.bit101.android.features.common.motion
+
+/*
+ * Copyright 2021 SOUP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+
+
+/**
+ * Returns the provided [Dp] as an [Int] value by the [LocalDensity].
+ *
+ * @param slideDistance Value to the slide distance dimension, 30dp by default.
+ */
+@Composable
+public fun rememberSlideDistance(
+    slideDistance: Dp = MotionConstants.DefaultSlideDistance,
+): Int {
+    val density = LocalDensity.current
+    return remember(density, slideDistance) {
+        with(density) { slideDistance.roundToPx() }
+    }
+}
+
+private const val ProgressThreshold = 0.35f
+
+private val Int.ForOutgoing: Int
+    get() = (this * ProgressThreshold).toInt()
+
+private val Int.ForIncoming: Int
+    get() = this - this.ForOutgoing
+
+/**
+ * [materialSharedAxisX] allows to switch a layout with shared X-axis transition.
+ *
+ */
+@OptIn(ExperimentalAnimationApi::class)
+public fun materialSharedAxisX(
+    initialOffsetX: (fullWidth: Int) -> Int,
+    targetOffsetX: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ContentTransform = ContentTransform(materialSharedAxisXIn(
+    initialOffsetX = initialOffsetX,
+    durationMillis = durationMillis
+), materialSharedAxisXOut(
+    targetOffsetX = targetOffsetX,
+    durationMillis = durationMillis
+))
+
+/**
+ * [materialSharedAxisXIn] allows to switch a layout with shared X-axis enter transition.
+ */
+public fun materialSharedAxisXIn(
+    initialOffsetX: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): EnterTransition = slideInHorizontally(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    initialOffsetX = initialOffsetX
+) + fadeIn(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForIncoming,
+        delayMillis = durationMillis.ForOutgoing,
+        easing = LinearOutSlowInEasing
+    )
+)
+
+/**
+ * [materialSharedAxisXOut] allows to switch a layout with shared X-axis exit transition.
+ *
+ */
+public fun materialSharedAxisXOut(
+    targetOffsetX: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ExitTransition = slideOutHorizontally(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    targetOffsetX = targetOffsetX
+) + fadeOut(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForOutgoing,
+        delayMillis = 0,
+        easing = FastOutLinearInEasing
+    )
+)
+
+
+/**
+ * [materialSharedAxisY] allows to switch a layout with shared Y-axis transition.
+ *
+ */
+@OptIn(ExperimentalAnimationApi::class)
+public fun materialSharedAxisY(
+    initialOffsetY: (fullWidth: Int) -> Int,
+    targetOffsetY: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ContentTransform = ContentTransform(materialSharedAxisYIn(
+    initialOffsetY = initialOffsetY,
+    durationMillis = durationMillis
+), materialSharedAxisYOut(
+    targetOffsetY = targetOffsetY,
+    durationMillis = durationMillis
+))
+
+/**
+ * [materialSharedAxisYIn] allows to switch a layout with shared Y-axis enter transition.
+ */
+public fun materialSharedAxisYIn(
+    initialOffsetY: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): EnterTransition = slideInVertically(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    initialOffsetY = initialOffsetY
+) + fadeIn(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForIncoming,
+        delayMillis = durationMillis.ForOutgoing,
+        easing = LinearOutSlowInEasing
+    )
+)
+
+/**
+ * [materialSharedAxisYOut] allows to switch a layout with shared X-axis exit transition.
+ *
+ */
+public fun materialSharedAxisYOut(
+    targetOffsetY: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ExitTransition = slideOutVertically (
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    targetOffsetY = targetOffsetY
+) + fadeOut(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForOutgoing,
+        delayMillis = 0,
+        easing = FastOutLinearInEasing
+    )
+)

--- a/features/common/src/main/java/cn/bit101/android/features/common/motion/MotionConstants.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/motion/MotionConstants.kt
@@ -17,6 +17,8 @@ package cn.bit101.android.features.common.motion
  */
 
 
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.Easing
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -25,4 +27,7 @@ public object MotionConstants {
     public const val DefaultFadeInDuration: Int = 150
     public const val DefaultFadeOutDuration: Int = 75
     public val DefaultSlideDistance: Dp = 30.dp
+
+    public val EmphasizedDecelerate: Easing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
+    public val EmphasizedAccelerate: Easing = CubicBezierEasing(0.3f, 0.0f, 0.8f, 0.15f)
 }

--- a/features/common/src/main/java/cn/bit101/android/features/common/motion/MotionConstants.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/motion/MotionConstants.kt
@@ -1,0 +1,28 @@
+package cn.bit101.android.features.common.motion
+
+/*
+ * Copyright 2021 SOUP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+public object MotionConstants {
+    public const val DefaultMotionDuration: Int = 300
+    public const val DefaultFadeInDuration: Int = 150
+    public const val DefaultFadeOutDuration: Int = 75
+    public val DefaultSlideDistance: Dp = 30.dp
+}

--- a/features/common/src/main/java/cn/bit101/android/features/common/nav/NavComposables.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/nav/NavComposables.kt
@@ -5,11 +5,8 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -23,6 +20,8 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import cn.bit101.android.features.common.motion.materialSharedAxisXIn
+import cn.bit101.android.features.common.motion.materialSharedAxisXOut
 
 /**
  * 所有动画的时长
@@ -37,36 +36,22 @@ val delayRemainTransition = fadeOut(tween(10, DURATION_MILLIS))
 /**
  * 从右侧滑入+淡入
  */
-val enterTransition = slideInHorizontally(
-    initialOffsetX = { it },
-    animationSpec = tween(
-        durationMillis = DURATION_MILLIS,
-        easing = FastOutSlowInEasing
-    )
-)
-//+ fadeIn(
-//    animationSpec = tween(
-//        durationMillis = DURATION_MILLIS,
-//        easing = FastOutSlowInEasing
-//    )
-//)
+val enterTransition = materialSharedAxisXIn({ (it * 0.1).toInt() })
+
+/**
+ * 向左侧滑出+淡出
+ */
+val exitTransition = materialSharedAxisXOut({ -(it * 0.1).toInt() })
+
+/**
+ * 从左侧滑入+淡入
+ */
+val popEnterTransition = materialSharedAxisXIn({ -(it * 0.1).toInt() })
 
 /**
  * 向右侧滑出+淡出
  */
-val exitTransition = slideOutHorizontally(
-    targetOffsetX = { it },
-    animationSpec = tween(
-        durationMillis = DURATION_MILLIS,
-        easing = FastOutSlowInEasing
-    )
-)
-//+ fadeOut(
-//    animationSpec = tween(
-//        durationMillis = DURATION_MILLIS,
-//        easing = LinearOutSlowInEasing
-//    )
-//)
+val popExitTransition = materialSharedAxisXOut({ (it * 0.1).toInt() })
 
 data class NavAnimation(
     val enterTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?,

--- a/features/gallery/src/main/java/cn/bit101/android/features/gallery/SearchPage.kt
+++ b/features/gallery/src/main/java/cn/bit101/android/features/gallery/SearchPage.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/SettingScreen.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/SettingScreen.kt
@@ -1,6 +1,5 @@
 package cn.bit101.android.features.setting
 
-import androidx.compose.animation.EnterTransition
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -10,9 +9,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import cn.bit101.android.features.common.MainController
 import cn.bit101.android.features.common.nav.NavDest
-import cn.bit101.android.features.common.nav.delayRemainTransition
 import cn.bit101.android.features.common.nav.enterTransition
 import cn.bit101.android.features.common.nav.exitTransition
+import cn.bit101.android.features.common.nav.popEnterTransition
+import cn.bit101.android.features.common.nav.popExitTransition
 import cn.bit101.android.features.setting.component.SettingPage
 import cn.bit101.android.features.setting.page.AboutPage
 import cn.bit101.android.features.setting.page.AccountPage
@@ -36,9 +36,9 @@ fun SettingScreen(
         navController = navController,
         startDestination = initialRoute.ifBlank { "index" },
         enterTransition = { enterTransition },
-        exitTransition = { delayRemainTransition },
-        popEnterTransition = { EnterTransition.None },
-        popExitTransition = { exitTransition },
+        exitTransition = { exitTransition },
+        popEnterTransition = { popEnterTransition },
+        popExitTransition = { popExitTransition },
     ) {
         composable("index") {
             SettingPage(

--- a/features/src/main/java/cn/bit101/android/features/MainApp.kt
+++ b/features/src/main/java/cn/bit101/android/features/MainApp.kt
@@ -1,6 +1,6 @@
 package cn.bit101.android.features
 
-import androidx.compose.animation.EnterTransition
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -35,9 +35,10 @@ import cn.bit101.android.features.common.nav.composableReport
 import cn.bit101.android.features.common.nav.composableSetting
 import cn.bit101.android.features.common.nav.composableUser
 import cn.bit101.android.features.common.nav.composableWeb
-import cn.bit101.android.features.common.nav.delayRemainTransition
 import cn.bit101.android.features.common.nav.enterTransition
 import cn.bit101.android.features.common.nav.exitTransition
+import cn.bit101.android.features.common.nav.popEnterTransition
+import cn.bit101.android.features.common.nav.popExitTransition
 import cn.bit101.android.features.common.utils.ColorUtils
 import cn.bit101.android.features.index.IndexScreen
 import cn.bit101.android.features.login.LoginOrLogoutScreen
@@ -69,7 +70,8 @@ internal fun MainApp() {
 
     val systemUiController = rememberSystemUiController()
 
-    val bottomNavBarColor = MaterialTheme.colorScheme.surface
+    val backgroundColor = MaterialTheme.colorScheme.surface
+    val bottomNavBarColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val darkTheme = !ColorUtils.isLightColor(MaterialTheme.colorScheme.background)
     LaunchedEffect(bottomNavBarColor, darkTheme) {
         systemUiController.setStatusBarColor(
@@ -78,7 +80,7 @@ internal fun MainApp() {
         )
 
         systemUiController.setNavigationBarColor(
-            color = bottomNavBarColor
+            color = Color.Transparent,
         )
     }
 
@@ -101,15 +103,19 @@ internal fun MainApp() {
     }
 
     NavHost(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize().background(color = backgroundColor),
         navController = navController,
         startDestination = NavDestConfig.Index.route,
+        enterTransition = { enterTransition },
+        exitTransition = { exitTransition },
+        popEnterTransition = { popEnterTransition },
+        popExitTransition = { popExitTransition },
     ) {
-        composableIndex(navController = navController) {
+        composableIndex(navAnim, navController = navController) {
             IndexScreen(mainController)
         }
 
-        composableLogin(navController = navController) {
+        composableLogin(navAnim, navController = navController) {
             LoginOrLogoutScreen(mainController)
         }
 
@@ -175,7 +181,7 @@ internal fun MainApp() {
  */
 private val navAnim = NavAnimation(
     enterTransition = { enterTransition },
-    exitTransition = { delayRemainTransition },
-    popEnterTransition = { EnterTransition.None },
-    popExitTransition = { exitTransition },
+    exitTransition = { exitTransition },
+    popEnterTransition = { popEnterTransition },
+    popExitTransition = { popExitTransition },
 )

--- a/features/src/main/java/cn/bit101/android/features/index/IndexViewModel.kt
+++ b/features/src/main/java/cn/bit101/android/features/index/IndexViewModel.kt
@@ -20,7 +20,9 @@ internal data class IndexPage(
     val page: PageShowOnNav,
     val label: String,
     val icon: ImageVector,
-)
+) {
+    val route = page.toString()
+}
 
 internal data class IndexScreenConfig(
     val pages: List<IndexPage>,

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 31 00:42:42 CST 2023
+#Mon Feb 17 16:54:34 CST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
跟着 Material You 指南中的 [Transition 章节](https://m3.material.io/styles/motion/transitions/transition-patterns) 改进了原有的过场动画. 

- 升级了 AGP 版本, 虽然我也不知道为什么要升级, 但是 Android Studio 这样提示的 ();
- 实现了 MaterialSharedAxis 的过渡动画;
- 用 NavHost 重新实现了 IndexScreen 的导航, 方便实现过渡动画 (原来用 HorizontalPager 的实现有点迷惑, 而且好像没法做复杂一点的 Transition). 

---

第一次接触安卓开发, 自然而然就拿 BIT101 练手了 ()

希望没犯很大的错误 qwq