### PR TITLE
添加空教室查询功能、话廊屏蔽机器人功能、话廊左右滑动切换选项卡功能、(非 Web 端) 话廊图片下载功能

### DIFF
--- a/api/src/main/java/cn/bit101/api/converter/login/GetSchoolInitLoginConvertFactory.kt
+++ b/api/src/main/java/cn/bit101/api/converter/login/GetSchoolInitLoginConvertFactory.kt
@@ -20,13 +20,12 @@ internal class GetSchoolInitLoginConvertFactory(
 
         return Converter<ResponseBody?, GetSchoolInitLoginDataModel.Response> {
             val html = it.string()
-            val ifLogin = html.indexOf("帐号登录或动态码登录") == -1
+            val ifLogin = html.indexOf("用户名密码") == -1   // TODO
 
             try {
                 val doc = Jsoup.parse(html)
-                val form = doc.select("#pwdFromId")
-                val salt = form.select("#pwdEncryptSalt").attr("value")
-                val execution = form.select("#execution").attr("value")
+                val salt = doc.select("#login-croypto").first()!!.childNode(0).toString()
+                val execution = doc.select("#login-page-flowkey").first()!!.childNode(0).toString()
 
                 GetSchoolInitLoginDataModel.Response(
                     html = html,

--- a/api/src/main/java/cn/bit101/api/converter/login/GetSchoolInitLoginConvertFactory.kt
+++ b/api/src/main/java/cn/bit101/api/converter/login/GetSchoolInitLoginConvertFactory.kt
@@ -20,7 +20,7 @@ internal class GetSchoolInitLoginConvertFactory(
 
         return Converter<ResponseBody?, GetSchoolInitLoginDataModel.Response> {
             val html = it.string()
-            val ifLogin = html.indexOf("用户名密码") == -1   // TODO
+            val ifLogin = html.indexOf("用户名密码") == -1
 
             try {
                 val doc = Jsoup.parse(html)

--- a/api/src/main/java/cn/bit101/api/converter/login/PostSchoolLoginConvertFactory.kt
+++ b/api/src/main/java/cn/bit101/api/converter/login/PostSchoolLoginConvertFactory.kt
@@ -20,7 +20,7 @@ internal class PostSchoolLoginConvertFactory(
         return Converter<ResponseBody?, PostSchoolLoginDataModel.Response> {
             val html = it.string()
 
-            val success = html.indexOf("帐号登录或动态码登录") == -1
+            val success = html.indexOf("用户名密码") == -1
 
             PostSchoolLoginDataModel.Response(
                 html = html,

--- a/api/src/main/java/cn/bit101/api/model/common/BuildingInfo.kt
+++ b/api/src/main/java/cn/bit101/api/model/common/BuildingInfo.kt
@@ -1,0 +1,11 @@
+package cn.bit101.api.model.common
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class BuildingInfo (
+    @SerializedName("JXLMC") val buildingName: String,          // 教学楼名, 和另一个字段 JXLJC 大部分时候是一样的
+    @SerializedName("JXLDM") val buildingIndex: String,         // 教学楼代码, 有点坑的是可能出现字母
+    @SerializedName("XXXQDM_DISPLAY") val campusName: String,   // 校区名
+    @SerializedName("XXXQDM") val campusIndex: Int              // 校区代码
+) : Serializable

--- a/api/src/main/java/cn/bit101/api/model/common/ClassroomInfo.kt
+++ b/api/src/main/java/cn/bit101/api/model/common/ClassroomInfo.kt
@@ -1,0 +1,9 @@
+package cn.bit101.api.model.common
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class ClassroomInfo (
+    @SerializedName("JASMC") val classroomName: String,
+    @SerializedName("ZYJC") val busyTimeStr: String?       // 非常坑的一点是这个可以是 null
+) : Serializable

--- a/api/src/main/java/cn/bit101/api/model/http/bit101/User.kt
+++ b/api/src/main/java/cn/bit101/api/model/http/bit101/User.kt
@@ -30,6 +30,8 @@ class PostWebvpnVerifyDataModel private constructor() {
         val execution: String,
         val cookie: String,
 
+        val salt: String,
+
         // 验证码，为空则不需要验证码
         val captcha: String? = null,
     )

--- a/api/src/main/java/cn/bit101/api/model/http/school/SchoolJxzxehallapp.kt
+++ b/api/src/main/java/cn/bit101/api/model/http/school/SchoolJxzxehallapp.kt
@@ -1,5 +1,7 @@
 package cn.bit101.api.model.http.school
 
+import cn.bit101.api.model.common.BuildingInfo
+import cn.bit101.api.model.common.ClassroomInfo
 import cn.bit101.api.model.common.CourseForSchedule
 import cn.bit101.api.model.common.TermForSchedule
 import com.google.gson.annotations.SerializedName
@@ -63,5 +65,33 @@ class PostGetScheduleDataModel private constructor() {
 
     data class Response(
         val datas: Datas
+    )
+}
+
+class GetBuildingTypeDataModel private constructor() {
+    data class CXJXL(
+        val rows: List<BuildingInfo>,
+    )
+
+    data class Datas(
+        val cxjxl: CXJXL
+    )
+
+    data class Response(
+        val datas: Datas,
+    )
+}
+
+class GetClassroomDataModel private constructor() {
+    data class CXKXJASQK(
+        val rows: List<ClassroomInfo>,
+    )
+
+    data class Datas(
+        val cxkxjasqk: CXKXJASQK
+    )
+
+    data class Response(
+        val datas: Datas,
     )
 }

--- a/api/src/main/java/cn/bit101/api/option/Options.kt
+++ b/api/src/main/java/cn/bit101/api/option/Options.kt
@@ -9,7 +9,7 @@ val DEFAULT_WEB_VPN_URLS = ApiUrlOption(
     jxzxehallappUrl = "https://webvpn.bit.edu.cn/https/77726476706e69737468656265737421faef5b842238695c720999bcd6572a216b231105adc27d",
     lexueUrl = "https://webvpn.bit.edu.cn/https/77726476706e69737468656265737421fcf25989227e6a596a468ca88d1b203b",
     androidUrl = "http://android.bit101.cn",
-    schoolLoginUrl = "https://login.bit.edu.cn"
+    schoolLoginUrl = "https://sso.bit.edu.cn"
 )
 
 val PROD_URLS = ApiUrlOption(
@@ -19,7 +19,7 @@ val PROD_URLS = ApiUrlOption(
     jxzxehallappUrl = "https://jxzxehallapp.bit.edu.cn",
     lexueUrl = "https://lexue.bit.edu.cn",
     androidUrl = "http://android.bit101.cn",
-    schoolLoginUrl = "https://login.bit.edu.cn"
+    schoolLoginUrl = "https://sso.bit.edu.cn"
 )
 
 val DEV_URLS = ApiUrlOption(
@@ -29,7 +29,7 @@ val DEV_URLS = ApiUrlOption(
     jxzxehallappUrl = "https://jxzxehallapp.bit.edu.cn",
     lexueUrl = "https://lexue.bit.edu.cn",
     androidUrl = "http://android.bit101.cn",
-    schoolLoginUrl = "https://login.bit.edu.cn"
+    schoolLoginUrl = "https://sso.bit.edu.cn"
 )
 
 

--- a/api/src/main/java/cn/bit101/api/service/school/SchoolJxzxehallappApiService.kt
+++ b/api/src/main/java/cn/bit101/api/service/school/SchoolJxzxehallappApiService.kt
@@ -1,9 +1,6 @@
 package cn.bit101.api.service.school
 
-import cn.bit101.api.model.http.school.GetCurrentTermDataModel
-import cn.bit101.api.model.http.school.PostGetScheduleDataModel
-import cn.bit101.api.model.http.school.GetTermsDataModel
-import cn.bit101.api.model.http.school.PostGetWeekAndDateDataModel
+import cn.bit101.api.model.http.school.*
 import cn.bit101.api.service.ApiService
 import okhttp3.MultipartBody
 import retrofit2.Response
@@ -17,6 +14,8 @@ import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 interface SchoolJxzxehallappApiService : ApiService {
     @GET("/jwapp/sys/wdkbby/*default/index.do")
@@ -50,4 +49,19 @@ interface SchoolJxzxehallappApiService : ApiService {
     suspend fun getWeekAndDate(
         @Field("requestParamStr") requestParamStr: String,
     ): Response<PostGetWeekAndDateDataModel.Response>
+
+    @GET("/jwapp/sys/kxjasbyMobile/modules/jxllb/cxjxl.do")
+    suspend fun getBuildingTypes(
+        @Query("XXXQDM") campusId: Int? = null,     // null 则不添加参数, 此时返回全部教学楼
+    ): Response<GetBuildingTypeDataModel.Response>
+
+    @FormUrlEncoded
+    @POST("/jwapp/sys/kxjasbyMobile/kxjasbyController/cxkxjasqk.do")
+    suspend fun getClassroomData(
+        @Field("XQDM") termId: String,   // 这个是 “学期代码” 而不是 “校区代码”，很坑......
+        @Field("JXLDM") buildingId: String,
+        @Field("RQ") date: String = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+        @Field("XNXQDM") termCode: String,  // 比如 2024-2025-2
+        @Field("XNDM") termYearCode: String,
+    ): Response<GetClassroomDataModel.Response>
 }

--- a/api/src/main/java/cn/bit101/api/service/school/SchoolUserApiService.kt
+++ b/api/src/main/java/cn/bit101/api/service/school/SchoolUserApiService.kt
@@ -14,28 +14,28 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface SchoolUserApiService : ApiService {
-    @GET("/authserver/login")
+    @GET("/cas/login")
     suspend fun initLogin(): Response<GetSchoolInitLoginDataModel.Response>
 
     @FormUrlEncoded
-    @POST("/authserver/login")
+    @POST("/cas/login")
     suspend fun login(
         @Field("username") username: String,
         @Field("password") password: String,
         @Field("execution") execution: String,
-        @Field("captcha") captcha: String = "",
+        @Field("croypto") salt: String,
+        @Field("captcha_payload") captchaPayload: String,
+        @Field("type") type: String = "UsernamePassword",
+        @Field("geolocation") geolocation: String = "",
+        @Field("captcha_code") captcha: String = "",
         @Field("_eventId") eventId: String = "submit",
-        @Field("cllt") cllt: String = "userNameLogin",
-        @Field("dllt") dllt: String = "generalLogin",
-        @Field("lt") lt: String = "",
-        @Field("rememberMe") rememberMe: String = "true",
     ): Response<PostSchoolLoginDataModel.Response>
 
-    @GET("/authserver/checkNeedCaptcha.htl")
+    @GET("/cas/checkNeedCaptcha.htl")
     suspend fun checkNeedCaptcha(
         @Query("username") username: String? = null,
     ): Response<GetCheckNeedCaptchaDataModel.Response>
 
-    @GET("/authserver/getCaptcha.htl")
+    @GET("/cas/getCaptcha.htl")
     suspend fun getCaptcha(): Response<String>
 }

--- a/config/src/main/java/cn/bit101/android/config/datastore/SettingDataStore.kt
+++ b/config/src/main/java/cn/bit101/android/config/datastore/SettingDataStore.kt
@@ -109,6 +109,14 @@ internal class SettingDataStore @Inject constructor(
     private val DDL_SCHEDULE_AFTER_DAY = longPreferencesKey("ddl_schedule_after_day")
     val ddlScheduleAfterDay = PreferencesDataStoreItem(DDL_SCHEDULE_AFTER_DAY, 3, preferences.SETTING_DATASTORE)
 
+    // 话廊设置
+    // 是否隐藏机器人 Poster
+    private val GALLERY_HIDE_BOT_POSTER = booleanPreferencesKey("gallery_hide_bot_poster")
+    val galleryHideBotPoster = PreferencesDataStoreItem(GALLERY_HIDE_BOT_POSTER, false, preferences.SETTING_DATASTORE)
+
+    // 是否包括搜索栏中的机器人 Poster
+    private val GALLERY_HIDE_BOT_POSTER_IN_SEARCH = booleanPreferencesKey("gallery_hide_bot_poster_in_search")
+    val galleryHideBotPosterInSearch = PreferencesDataStoreItem(GALLERY_HIDE_BOT_POSTER_IN_SEARCH, false, preferences.SETTING_DATASTORE)
 
     // 主页设置
     private val HOME_PAGE = stringPreferencesKey("home_page")

--- a/config/src/main/java/cn/bit101/android/config/datastore/SettingDataStore.kt
+++ b/config/src/main/java/cn/bit101/android/config/datastore/SettingDataStore.kt
@@ -1,6 +1,5 @@
 package cn.bit101.android.config.datastore
 
-import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
@@ -109,6 +108,19 @@ internal class SettingDataStore @Inject constructor(
     private val DDL_SCHEDULE_AFTER_DAY = longPreferencesKey("ddl_schedule_after_day")
     val ddlScheduleAfterDay = PreferencesDataStoreItem(DDL_SCHEDULE_AFTER_DAY, 3, preferences.SETTING_DATASTORE)
 
+    // 空教室检索设置
+    // 当前校区名
+    private val FREE_CLASSROOM_CURRENT_CAMPUS = stringPreferencesKey("free_classroom_campus")
+    val freeClassroomCurrentCampus = PreferencesDataStoreItem(FREE_CLASSROOM_CURRENT_CAMPUS, "", preferences.SETTING_DATASTORE)
+
+    // 是否隐藏不空闲的教室
+    private val FREE_CLASSROOM_HIDE_BUSY_CLASSROOM = booleanPreferencesKey("free_classroom_hide_busy_classroom")
+    val freeClassroomHideBusyClassroom = PreferencesDataStoreItem(FREE_CLASSROOM_HIDE_BUSY_CLASSROOM, true, preferences.SETTING_DATASTORE)
+
+    // 最小空闲阈值
+    private val FREE_CLASSROOM_FREE_MINUTES_THRESHOLD = longPreferencesKey("free_classroom_free_minutes_threshold")
+    val freeClassroomFreeMinutesThreshold = PreferencesDataStoreItem(FREE_CLASSROOM_FREE_MINUTES_THRESHOLD, 5, preferences.SETTING_DATASTORE)
+
     // 话廊设置
     // 是否隐藏机器人 Poster
     private val GALLERY_HIDE_BOT_POSTER = booleanPreferencesKey("gallery_hide_bot_poster")
@@ -117,6 +129,10 @@ internal class SettingDataStore @Inject constructor(
     // 是否包括搜索栏中的机器人 Poster
     private val GALLERY_HIDE_BOT_POSTER_IN_SEARCH = booleanPreferencesKey("gallery_hide_bot_poster_in_search")
     val galleryHideBotPosterInSearch = PreferencesDataStoreItem(GALLERY_HIDE_BOT_POSTER_IN_SEARCH, false, preferences.SETTING_DATASTORE)
+
+    // 是否允许横向滚动
+    private val GALLERY_ALLOW_HORIZONAL_SCROLL = booleanPreferencesKey("gallery_allow_horizonal_scroll")
+    val galleryAllowHorizonalScroll = PreferencesDataStoreItem(GALLERY_ALLOW_HORIZONAL_SCROLL, false, preferences.SETTING_DATASTORE)
 
     // 主页设置
     private val HOME_PAGE = stringPreferencesKey("home_page")

--- a/config/src/main/java/cn/bit101/android/config/setting/DefaultFreeClassroomSettings.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/DefaultFreeClassroomSettings.kt
@@ -1,0 +1,17 @@
+package cn.bit101.android.config.setting
+
+import cn.bit101.android.config.common.SettingItem
+import cn.bit101.android.config.common.toSettingItem
+import cn.bit101.android.config.datastore.SettingDataStore
+import cn.bit101.android.config.setting.base.FreeClassroomSettings
+import javax.inject.Inject
+
+internal class DefaultFreeClassroomSettings @Inject constructor(
+    settingDataStore: SettingDataStore
+) : FreeClassroomSettings{
+    override val currentCampus: SettingItem<String> = settingDataStore.freeClassroomCurrentCampus.toSettingItem()
+
+    override val hideBusyClassroom: SettingItem<Boolean> = settingDataStore.freeClassroomHideBusyClassroom.toSettingItem()
+
+    override val freeMinutesThreshold: SettingItem<Long> = settingDataStore.freeClassroomFreeMinutesThreshold.toSettingItem()
+}

--- a/config/src/main/java/cn/bit101/android/config/setting/DefaultGallerySettings.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/DefaultGallerySettings.kt
@@ -11,4 +11,6 @@ internal class DefaultGallerySettings @Inject constructor(
 ) : GallerySettings {
     override val hideBotPoster: SettingItem<Boolean> = settingDataStore.galleryHideBotPoster.toSettingItem()
     override val hideBotPosterInSearch: SettingItem<Boolean> = settingDataStore.galleryHideBotPosterInSearch.toSettingItem()
+
+    override val allowHorizontalScroll: SettingItem<Boolean> = settingDataStore.galleryAllowHorizonalScroll.toSettingItem()
 }

--- a/config/src/main/java/cn/bit101/android/config/setting/DefaultGallerySettings.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/DefaultGallerySettings.kt
@@ -1,0 +1,14 @@
+package cn.bit101.android.config.setting
+
+import cn.bit101.android.config.common.SettingItem
+import cn.bit101.android.config.common.toSettingItem
+import cn.bit101.android.config.datastore.SettingDataStore
+import cn.bit101.android.config.setting.base.GallerySettings
+import javax.inject.Inject
+
+internal class DefaultGallerySettings @Inject constructor(
+    settingDataStore: SettingDataStore
+) : GallerySettings {
+    override val hideBotPoster: SettingItem<Boolean> = settingDataStore.galleryHideBotPoster.toSettingItem()
+    override val hideBotPosterInSearch: SettingItem<Boolean> = settingDataStore.galleryHideBotPosterInSearch.toSettingItem()
+}

--- a/config/src/main/java/cn/bit101/android/config/setting/SettingModule.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/SettingModule.kt
@@ -52,4 +52,10 @@ internal abstract class SettingModule {
     abstract fun bindGallerySettings(
         gallerySettings: DefaultGallerySettings
     ): GallerySettings
+
+    @Binds
+    @Singleton
+    abstract fun bindFreeClassroomSettings(
+        freeClassroomSettings: DefaultFreeClassroomSettings
+    ): FreeClassroomSettings
 }

--- a/config/src/main/java/cn/bit101/android/config/setting/SettingModule.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/SettingModule.kt
@@ -1,11 +1,6 @@
 package cn.bit101.android.config.setting
 
-import cn.bit101.android.config.setting.base.AboutSettings
-import cn.bit101.android.config.setting.base.CourseScheduleSettings
-import cn.bit101.android.config.setting.base.DDLSettings
-import cn.bit101.android.config.setting.base.MapSettings
-import cn.bit101.android.config.setting.base.PageSettings
-import cn.bit101.android.config.setting.base.ThemeSettings
+import cn.bit101.android.config.setting.base.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -51,4 +46,10 @@ internal abstract class SettingModule {
     abstract fun bindMapSettings(
         mapSettings: DefaultMapSettings
     ): MapSettings
+
+    @Binds
+    @Singleton
+    abstract fun bindGallerySettings(
+        gallerySettings: DefaultGallerySettings
+    ): GallerySettings
 }

--- a/config/src/main/java/cn/bit101/android/config/setting/base/FreeClassroomSettings.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/base/FreeClassroomSettings.kt
@@ -1,0 +1,12 @@
+package cn.bit101.android.config.setting.base
+
+import cn.bit101.android.config.common.SettingItem
+
+interface FreeClassroomSettings {
+    val currentCampus: SettingItem<String>
+
+    val hideBusyClassroom: SettingItem<Boolean>
+
+    // 最小空闲时间阈值, 不大于该阈值的空闲时间都不被视作空闲
+    val freeMinutesThreshold: SettingItem<Long>
+}

--- a/config/src/main/java/cn/bit101/android/config/setting/base/GallerySettings.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/base/GallerySettings.kt
@@ -1,0 +1,8 @@
+package cn.bit101.android.config.setting.base
+
+import cn.bit101.android.config.common.SettingItem
+
+interface GallerySettings {
+    val hideBotPoster: SettingItem<Boolean>
+    val hideBotPosterInSearch: SettingItem<Boolean>
+}

--- a/config/src/main/java/cn/bit101/android/config/setting/base/GallerySettings.kt
+++ b/config/src/main/java/cn/bit101/android/config/setting/base/GallerySettings.kt
@@ -5,4 +5,6 @@ import cn.bit101.android.config.common.SettingItem
 interface GallerySettings {
     val hideBotPoster: SettingItem<Boolean>
     val hideBotPosterInSearch: SettingItem<Boolean>
+
+    val allowHorizontalScroll: SettingItem<Boolean>
 }

--- a/data/src/main/java/cn/bit101/android/data/common/AESUtils.kt
+++ b/data/src/main/java/cn/bit101/android/data/common/AESUtils.kt
@@ -43,13 +43,16 @@ internal object AESUtils {
         }
     }
 
-    // 适配新版的学校统一认证, TODO
+    // 适配新版的学校统一认证
     fun encryptPasswordNew(password: String, loginCrypto: String): String {
+        val passwordBytes = password.toByteArray(Charsets.UTF_8)
+
         val decodedKey = Base64.getDecoder().decode(loginCrypto)
         val secretKey = SecretKeySpec(decodedKey, "AES")
         val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+
         cipher.init(Cipher.ENCRYPT_MODE, secretKey)
-        val encryptedBytes = cipher.doFinal(password.toByteArray(Charsets.UTF_8))
+        val encryptedBytes = cipher.doFinal(passwordBytes)
         return Base64.getEncoder().encodeToString(encryptedBytes)
     }
 }

--- a/data/src/main/java/cn/bit101/android/data/common/AESUtils.kt
+++ b/data/src/main/java/cn/bit101/android/data/common/AESUtils.kt
@@ -42,4 +42,14 @@ internal object AESUtils {
             encryptAES(data, salt, randomString(16))
         }
     }
+
+    // 适配新版的学校统一认证, TODO
+    fun encryptPasswordNew(password: String, loginCrypto: String): String {
+        val decodedKey = Base64.getDecoder().decode(loginCrypto)
+        val secretKey = SecretKeySpec(decodedKey, "AES")
+        val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        val encryptedBytes = cipher.doFinal(password.toByteArray(Charsets.UTF_8))
+        return Base64.getEncoder().encodeToString(encryptedBytes)
+    }
 }

--- a/data/src/main/java/cn/bit101/android/data/common/AESUtils.kt
+++ b/data/src/main/java/cn/bit101/android/data/common/AESUtils.kt
@@ -10,41 +10,7 @@ import javax.crypto.spec.SecretKeySpec
  * AES 加密工具类，与登录相关
  */
 internal object AESUtils {
-    private const val AES_CHARS = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678"
-
-    private fun encryptAES(data: String, key: String, iv: String): String {
-        val keyBytes = key.toByteArray(Charsets.UTF_8)
-        val ivBytes = iv.toByteArray(Charsets.UTF_8)
-        val dataBytes = data.toByteArray(Charsets.UTF_8)
-
-        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
-        val secretKey = SecretKeySpec(keyBytes, "AES")
-        val ivSpec = IvParameterSpec(ivBytes)
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivSpec)
-        val encrypted = cipher.doFinal(dataBytes)
-        return Base64.getEncoder().encodeToString(encrypted)
-    }
-
-    private fun randomString(length: Int): String {
-        val random = SecureRandom()
-        val sb = StringBuilder(length)
-        repeat(length) {
-            val index = random.nextInt(AES_CHARS.length)
-            sb.append(AES_CHARS[index])
-        }
-        return sb.toString()
-    }
-
-    fun encryptPassword(password: String, salt: String): String {
-        return if (salt.isEmpty()) password
-        else {
-            val data = randomString(64) + password
-            encryptAES(data, salt, randomString(16))
-        }
-    }
-
-    // 适配新版的学校统一认证
-    fun encryptPasswordNew(password: String, loginCrypto: String): String {
+    fun encryptPassword(password: String, loginCrypto: String): String {
         val passwordBytes = password.toByteArray(Charsets.UTF_8)
 
         val decodedKey = Base64.getDecoder().decode(loginCrypto)

--- a/data/src/main/java/cn/bit101/android/data/repo/DefaultFreeClassroomRepo.kt
+++ b/data/src/main/java/cn/bit101/android/data/repo/DefaultFreeClassroomRepo.kt
@@ -2,7 +2,6 @@ package cn.bit101.android.data.repo
 
 import cn.bit101.android.config.setting.base.CourseScheduleSettings
 import cn.bit101.android.config.setting.base.FreeClassroomSettings
-import cn.bit101.android.data.database.BIT101Database
 import cn.bit101.android.data.net.base.APIManager
 import cn.bit101.android.data.repo.base.FreeClassroomRepo
 import cn.bit101.api.model.common.BuildingInfo
@@ -12,8 +11,7 @@ import java.io.IOException
 import javax.inject.Inject
 
 internal class DefaultFreeClassroomRepo @Inject constructor(
-    private val database: BIT101Database,
-    private val apiManager: APIManager,
+    apiManager: APIManager,
     private val freeClassroomSettings: FreeClassroomSettings,
     private val scheduleSettings: CourseScheduleSettings
 ): FreeClassroomRepo{

--- a/data/src/main/java/cn/bit101/android/data/repo/DefaultFreeClassroomRepo.kt
+++ b/data/src/main/java/cn/bit101/android/data/repo/DefaultFreeClassroomRepo.kt
@@ -1,0 +1,46 @@
+package cn.bit101.android.data.repo
+
+import cn.bit101.android.config.setting.base.CourseScheduleSettings
+import cn.bit101.android.config.setting.base.FreeClassroomSettings
+import cn.bit101.android.data.database.BIT101Database
+import cn.bit101.android.data.net.base.APIManager
+import cn.bit101.android.data.repo.base.FreeClassroomRepo
+import cn.bit101.api.model.common.BuildingInfo
+import cn.bit101.api.model.common.ClassroomInfo
+import kotlinx.coroutines.flow.Flow
+import java.io.IOException
+import javax.inject.Inject
+
+internal class DefaultFreeClassroomRepo @Inject constructor(
+    private val database: BIT101Database,
+    private val apiManager: APIManager,
+    private val freeClassroomSettings: FreeClassroomSettings,
+    private val scheduleSettings: CourseScheduleSettings
+): FreeClassroomRepo{
+    val api = apiManager.api
+
+    override suspend fun getBuildingInfos(campusId: Int?): List<BuildingInfo> {
+        api.schoolJxzxehallapp.getAppConfig()   // 不加这个会出奇怪的错误
+        api.schoolJxzxehallapp.switchLang()
+
+        val responseBody = api.schoolJxzxehallapp.getBuildingTypes(campusId).body() ?: throw IOException("get buildingTypes error")
+
+        return responseBody.datas.cxjxl.rows
+    }
+
+    override suspend fun getClassroomInfos(buildingId: String): List<ClassroomInfo> {
+        api.schoolJxzxehallapp.getAppConfig()
+        api.schoolJxzxehallapp.switchLang()
+
+        val responseBody = api.schoolJxzxehallapp.getClassroomData(
+            buildingId = buildingId,
+            termCode = scheduleSettings.term.get(),
+            termYearCode = scheduleSettings.term.get().dropLastWhile { it != '-' }.dropLast(1),
+            termId = scheduleSettings.term.get().takeLastWhile { it!='-' }
+        ).body() ?: throw IOException("getClassroomData error")
+
+        return responseBody.datas.cxkxjasqk.rows
+    }
+
+    override fun getCurrentCampus(): Flow<String> = freeClassroomSettings.currentCampus.flow
+}

--- a/data/src/main/java/cn/bit101/android/data/repo/DefaultLoginRepo.kt
+++ b/data/src/main/java/cn/bit101/android/data/repo/DefaultLoginRepo.kt
@@ -72,14 +72,14 @@ internal class DefaultLoginRepo @Inject constructor(
             finalExecution = initResponse.execution
         }
 
-        val cryptPassword = AESUtils.encryptPasswordNew(password, finalSalt ?: "")
+        val cryptPassword = AESUtils.encryptPassword(password, finalSalt ?: "")
 
         val res = api.schoolUser.login(
             username = username,
             password = cryptPassword,
             execution = finalExecution ?: "",
             salt = finalSalt ?: "",
-            captchaPayload = AESUtils.encryptPasswordNew("{}", finalSalt ?: "") // 去掉似乎也没问题
+            captchaPayload = AESUtils.encryptPassword("{}", finalSalt ?: "") // 去掉似乎也没问题
             // 不需要验证码:
             // 这里模拟的是正式的登录请求 (对应开发者工具的 Network 里的 login)
             // 官方网页端会在发送这个正式登录请求前先发送一个验证码请求, 检查是否需要验证码 (/cas/api/protected/user/findCaptchaCount/{学号}?{一串数字})
@@ -114,6 +114,7 @@ internal class DefaultLoginRepo @Inject constructor(
                 password = encryptedPassword,
                 execution = execution,
                 cookie = cookie,
+                salt = salt,
                 captcha = ""
             )
         ).body() ?: throw Exception("get webVpnVerify response error")

--- a/data/src/main/java/cn/bit101/android/data/repo/DefaultLoginRepo.kt
+++ b/data/src/main/java/cn/bit101/android/data/repo/DefaultLoginRepo.kt
@@ -72,12 +72,14 @@ internal class DefaultLoginRepo @Inject constructor(
             finalExecution = initResponse.execution
         }
 
-        val cryptPassword = AESUtils.encryptPassword(password, finalSalt ?: "")
+        val cryptPassword = AESUtils.encryptPasswordNew(password, finalSalt ?: "")
 
         val res = api.schoolUser.login(
             username = username,
             password = cryptPassword,
             execution = finalExecution ?: "",
+            salt = finalSalt ?: "",
+            captchaPayload = AESUtils.encryptPasswordNew("{}", finalSalt ?: "")
         ).body() ?: throw Exception("login response error")
         res.success
     }

--- a/data/src/main/java/cn/bit101/android/data/repo/DefaultPosterRepo.kt
+++ b/data/src/main/java/cn/bit101/android/data/repo/DefaultPosterRepo.kt
@@ -3,7 +3,6 @@ package cn.bit101.android.data.repo
 import cn.bit101.android.config.setting.base.GallerySettings
 import cn.bit101.android.data.net.base.APIManager
 import cn.bit101.android.data.repo.base.PosterRepo
-import cn.bit101.api.model.common.CommentsOrder
 import cn.bit101.api.model.common.PostersFilter
 import cn.bit101.api.model.common.PostersMode
 import cn.bit101.api.model.common.PostersOrder
@@ -15,7 +14,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 internal class DefaultPosterRepo @Inject constructor(
-    private val apiManager: APIManager,
+    apiManager: APIManager,
     private val gallerySettings: GallerySettings
 ) : PosterRepo {
 
@@ -26,8 +25,8 @@ internal class DefaultPosterRepo @Inject constructor(
                            page: Long? = null,
                            search: String? = null,
                            uid: Int? = null,
-                           noBot: Boolean = false): GetPostersDataModel.Response
-    {
+                           noBot: Boolean = false
+    ): GetPostersDataModel.Response {
         val datas = api.posters.getPosters(mode,order,page,search,uid).body() ?: throw Exception("get posters error")
 
         if(noBot)

--- a/data/src/main/java/cn/bit101/android/data/repo/RepoModule.kt
+++ b/data/src/main/java/cn/bit101/android/data/repo/RepoModule.kt
@@ -1,15 +1,6 @@
 package cn.bit101.android.data.repo
 
-import cn.bit101.android.data.repo.base.CoursesRepo
-import cn.bit101.android.data.repo.base.DDLScheduleRepo
-import cn.bit101.android.data.repo.base.LoginRepo
-import cn.bit101.android.data.repo.base.ManageRepo
-import cn.bit101.android.data.repo.base.MessageRepo
-import cn.bit101.android.data.repo.base.PosterRepo
-import cn.bit101.android.data.repo.base.ReactionRepo
-import cn.bit101.android.data.repo.base.UploadRepo
-import cn.bit101.android.data.repo.base.UserRepo
-import cn.bit101.android.data.repo.base.VersionRepo
+import cn.bit101.android.data.repo.base.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -78,4 +69,10 @@ internal abstract class RepoModule {
     abstract fun bindLoginRepo(
         loginRepo: DefaultLoginRepo
     ): LoginRepo
+
+    @Binds
+    @Singleton
+    abstract fun bindFreeClassroomRepo(
+        freeClassroomRepo: DefaultFreeClassroomRepo
+    ): FreeClassroomRepo
 }

--- a/data/src/main/java/cn/bit101/android/data/repo/base/FreeClassroomRepo.kt
+++ b/data/src/main/java/cn/bit101/android/data/repo/base/FreeClassroomRepo.kt
@@ -1,0 +1,13 @@
+package cn.bit101.android.data.repo.base
+
+import cn.bit101.api.model.common.BuildingInfo
+import cn.bit101.api.model.common.ClassroomInfo
+import kotlinx.coroutines.flow.Flow
+
+interface FreeClassroomRepo {
+    suspend fun getBuildingInfos(campusId: Int? = null): List<BuildingInfo>
+
+    suspend fun getClassroomInfos(buildingId: String): List<ClassroomInfo>
+
+    fun getCurrentCampus() : Flow<String>
+}

--- a/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageHost.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageHost.kt
@@ -57,14 +57,14 @@ class ImageHostState(
 fun ImageHost(
     modifier: Modifier = Modifier,
     state: ImageHostState,
-    onOpenUrl: (String, ()->Unit) -> Unit,
+    onDownloadImage: (String, ()->Unit) -> Unit,
 ) {
     Box(modifier = modifier) {
         when(val data = state.data) {
             is ImageHostData.Single -> {
                 ImageScreen(
                     image = data.image,
-                    onOpenUrl = onOpenUrl,
+                    onDownloadImage = onDownloadImage,
                     onDismiss = state::dismiss
                 )
             }
@@ -72,7 +72,7 @@ fun ImageHost(
                 ImageScreen(
                     images = data.images,
                     initialIndex = data.index,
-                    onOpenUrl = onOpenUrl,
+                    onDownloadImage = onDownloadImage,
                     onDismiss = state::dismiss
                 )
             }

--- a/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageHost.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageHost.kt
@@ -57,7 +57,7 @@ class ImageHostState(
 fun ImageHost(
     modifier: Modifier = Modifier,
     state: ImageHostState,
-    onOpenUrl: (String) -> Unit,
+    onOpenUrl: (String, ()->Unit) -> Unit,
 ) {
     Box(modifier = modifier) {
         when(val data = state.data) {

--- a/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageScreen.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageScreen.kt
@@ -287,7 +287,7 @@ private fun BasicImageScreen(
 internal fun ImageScreen(
     image: ImageData,
 
-    onOpenUrl: (String) -> Unit,
+    onOpenUrl: (String, ()->Unit) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val state = rememberImageShowState(
@@ -325,7 +325,7 @@ internal fun ImageScreen(
     images: List<ImageData>,
     initialIndex: Int,
 
-    onOpenUrl: (String) -> Unit,
+    onOpenUrl: (String, ()->Unit) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val state = rememberSeriesImagesShowState(

--- a/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageScreen.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageScreen.kt
@@ -287,7 +287,7 @@ private fun BasicImageScreen(
 internal fun ImageScreen(
     image: ImageData,
 
-    onOpenUrl: (String, ()->Unit) -> Unit,
+    onDownloadImage: (String, ()->Unit) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val state = rememberImageShowState(
@@ -304,7 +304,7 @@ internal fun ImageScreen(
                     .align(Alignment.BottomCenter)
                     .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)),
                 state = state,
-                onOpenUrl = onOpenUrl
+                onOpenUrl = onDownloadImage
             )
         },
         imageContent = {
@@ -325,7 +325,7 @@ internal fun ImageScreen(
     images: List<ImageData>,
     initialIndex: Int,
 
-    onOpenUrl: (String, ()->Unit) -> Unit,
+    onDownloadImage: (String, ()->Unit) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val state = rememberSeriesImagesShowState(
@@ -344,7 +344,7 @@ internal fun ImageScreen(
                     .align(Alignment.BottomCenter)
                     .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)),
                 state = state,
-                onOpenUrl = onOpenUrl,
+                onOpenUrl = onDownloadImage,
             )
         },
         imageContent = {

--- a/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageScreenController.kt
+++ b/features/common/src/main/java/cn/bit101/android/features/common/component/image/ImageScreenController.kt
@@ -1,27 +1,12 @@
 package cn.bit101.android.features.common.component.image
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.ArrowBackIos
 import androidx.compose.material.icons.automirrored.rounded.ArrowForwardIos
 import androidx.compose.material.icons.rounded.Download
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FilledTonalIconButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -31,7 +16,7 @@ import cn.bit101.android.features.common.helper.ImageData
 internal fun ImageController(
     modifier: Modifier,
     state: SeriesImagesShowState,
-    onOpenUrl: (String) -> Unit,
+    onOpenUrl: (String, ()->Unit) -> Unit,
 ) {
 
     val currentState = state.currentState
@@ -41,6 +26,8 @@ internal fun ImageController(
         is ImageData.RemoteUseUrl -> currentState.image.url
         else -> null
     }
+
+    var nowDownloadingImage by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Row(
@@ -110,9 +97,21 @@ internal fun ImageController(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.8f),
                     contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 ),
-                onClick = { onOpenUrl(url) }
+                onClick = {
+                    nowDownloadingImage = true
+                    onOpenUrl(url) { nowDownloadingImage = false }
+                }
             ) {
-                Icon(imageVector = Icons.Rounded.Download, contentDescription = "download")
+                if(nowDownloadingImage)
+                    CircularProgressIndicator(
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        strokeWidth = 2.5.dp,
+                        modifier = Modifier
+                            .matchParentSize()
+                            .padding(7.5.dp)
+                    )
+                else
+                    Icon(imageVector = Icons.Rounded.Download, contentDescription = "download")
             }
         }
     }
@@ -123,13 +122,16 @@ internal fun ImageController(
 internal fun ImageController(
     modifier: Modifier,
     state: ImageShowState,
-    onOpenUrl: (String) -> Unit,
+    onOpenUrl: (String, ()->Unit) -> Unit,
 ) {
     val url = when(state.image) {
         is ImageData.Remote -> state.image.image.url
         is ImageData.RemoteUseUrl -> state.image.url
         else -> null
     }
+
+    var nowDownloadingImage by remember { mutableStateOf(false) }
+
     Box(modifier = Modifier.fillMaxSize()) {
 
         if (url != null) {
@@ -141,9 +143,21 @@ internal fun ImageController(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.8f),
                     contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 ),
-                onClick = { onOpenUrl(url) }
+                onClick = {
+                    nowDownloadingImage = true
+                    onOpenUrl(url) { nowDownloadingImage = false }
+                }
             ) {
-                Icon(imageVector = Icons.Rounded.Download, contentDescription = "download")
+                if(nowDownloadingImage)
+                    CircularProgressIndicator(
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        strokeWidth = 2.5.dp,
+                        modifier = Modifier
+                            .matchParentSize()
+                            .padding(7.5.dp)
+                    )
+                else
+                    Icon(imageVector = Icons.Rounded.Download, contentDescription = "download")
             }
         }
     }

--- a/features/gallery/src/main/java/cn/bit101/android/features/gallery/GalleryIndexViewModel.kt
+++ b/features/gallery/src/main/java/cn/bit101/android/features/gallery/GalleryIndexViewModel.kt
@@ -1,6 +1,5 @@
 package cn.bit101.android.features.gallery
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cn.bit101.android.config.setting.base.GallerySettings
@@ -82,4 +81,6 @@ internal class GalleryIndexViewModel @Inject constructor(
         }
     }
     val searchStateExports = _searchState.export()
+
+    val enableHorizontalScrollFlow = gallerySettings.allowHorizontalScroll.flow
 }

--- a/features/gallery/src/main/java/cn/bit101/android/features/gallery/GalleryScreen.kt
+++ b/features/gallery/src/main/java/cn/bit101/android/features/gallery/GalleryScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.ArrowUpward
 import androidx.compose.material.icons.rounded.Search
@@ -65,6 +66,8 @@ fun GalleryScreen(
     val searchPosters by vm.searchStateExports.dataFlow.collectAsState()
 
     var searchData by rememberSaveable { mutableStateOf(SearchData.default) }
+
+    val enableHorizontalScroll by vm.enableHorizontalScrollFlow.collectAsState(initial = false)
 
     val followState = rememberLoadableLazyColumnState(
         refreshing = followRefreshState == SimpleState.Loading,
@@ -274,19 +277,22 @@ fun GalleryScreen(
                 ) {
                     HorizontalPager(
                         state = horizontalPagerState,
+                        userScrollEnabled = enableHorizontalScroll,
                     ) { index ->
                         pages[index].content()
                     }
 
                     val postersState = posterStates[horizontalPagerState.currentPage]
 
-                    if(postersState.refreshState is SimpleState.Success) {
+                    // 右下角按钮组
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(10.dp, 20.dp, 10.dp, 20.dp)
+                    ) {
                         val fabSize = 42.dp
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.BottomEnd)
-                                .padding(10.dp, 20.dp, 10.dp, 20.dp)
-                        ) {
+
+                        if (postersState.refreshState is SimpleState.Success) {
                             val show by remember { derivedStateOf { posterStates[horizontalPagerState.currentPage].state.lazyListState.firstVisibleItemIndex > 1 } }
                             AnimatedVisibility(
                                 visible = show,
@@ -326,6 +332,23 @@ fun GalleryScreen(
                                     contentDescription = "张贴Poster"
                                 )
                             }
+
+                            Spacer(modifier = Modifier.height(10.dp))
+                        }
+
+                        // 无论有没有加载出来都可以把设置按钮显示出来
+                        FloatingActionButton(
+                            modifier = Modifier
+                                .size(fabSize),
+                            onClick = { mainController.navigate(NavDest.Setting("gallery")) },
+                            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(0.8f),
+                            contentColor = MaterialTheme.colorScheme.primary,
+                            elevation = FloatingActionButtonDefaults.elevation(0.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Settings,
+                                contentDescription = "settings",
+                            )
                         }
                     }
                 }

--- a/features/gallery/src/main/java/cn/bit101/android/features/gallery/PostersTabPage.kt
+++ b/features/gallery/src/main/java/cn/bit101/android/features/gallery/PostersTabPage.kt
@@ -119,55 +119,5 @@ internal fun PostersTabPage(
                 )
             }
         }
-        if(postersState.refreshState is SimpleState.Success) {
-            val fabSize = 42.dp
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(10.dp, 20.dp, 10.dp, 20.dp)
-            ) {
-                val show by remember { derivedStateOf { postersState.state.lazyListState.firstVisibleItemIndex > 1 } }
-                AnimatedVisibility(
-                    visible = show,
-                    enter = fadeIn(),
-                    exit = fadeOut()
-                ) {
-                    FloatingActionButton(
-                        modifier = Modifier
-                            .size(fabSize),
-                        onClick = {
-                            scope.launch {
-                                postersState.state.lazyListState.animateScrollToItem(0, 0)
-                            }
-                        },
-                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(0.8f),
-                        contentColor = MaterialTheme.colorScheme.primary,
-                        elevation = FloatingActionButtonDefaults.elevation(0.dp),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.ArrowUpward,
-                            contentDescription = "回到顶部"
-                        )
-                    }
-                }
-
-                if(showPostButton) {
-                    Spacer(modifier = Modifier.height(10.dp))
-
-                    FloatingActionButton(
-                        modifier = Modifier.size(fabSize),
-                        onClick = onOpenPostOrEdit,
-                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(0.8f),
-                        contentColor = MaterialTheme.colorScheme.primary,
-                        elevation = FloatingActionButtonDefaults.elevation(0.dp),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Add,
-                            contentDescription = "张贴Poster"
-                        )
-                    }
-                }
-            }
-        }
     }
 }

--- a/features/mine/src/main/java/cn/bit101/android/features/mine/MineViewModel.kt
+++ b/features/mine/src/main/java/cn/bit101/android/features/mine/MineViewModel.kt
@@ -3,6 +3,7 @@ package cn.bit101.android.features.mine
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cn.bit101.android.config.setting.base.GallerySettings
 import cn.bit101.android.data.repo.base.MessageRepo
 import cn.bit101.android.data.repo.base.PosterRepo
 import cn.bit101.android.data.repo.base.UserRepo
@@ -19,25 +20,26 @@ import javax.inject.Inject
 internal class MineViewModel @Inject constructor(
     private val userRepo: UserRepo,
     private val posterRepo: PosterRepo,
-    private val messageRepo: MessageRepo
+    private val messageRepo: MessageRepo,
+    private val gallerySettings: GallerySettings,
 ) : ViewModel() {
     val userInfoStateLiveData = MutableLiveData<SimpleDataState<GetUserInfoDataModel.Response>?>(null)
 
     val messageCountStateLiveData = MutableLiveData<SimpleDataState<Int>?>(null)
 
-    private val _followingState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope) {
+    private val _followingState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope, gallerySettings) {
         override fun refresh() = refresh { userRepo.getFollowings() }
         override fun loadMore() = loadMore { userRepo.getFollowings(it.toInt()) }
     }
     val followingStateExports = _followingState.export()
 
-    private val _followerState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope) {
+    private val _followerState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope, gallerySettings) {
         override fun refresh() = refresh { userRepo.getFollowers() }
         override fun loadMore() = loadMore { userRepo.getFollowers(it.toInt()) }
     }
     val followerStateExports = _followerState.export()
 
-    private val _postersState = object : RefreshAndLoadMoreStatesCombinedZero<GetPostersDataModel.ResponseItem>(viewModelScope) {
+    private val _postersState = object : RefreshAndLoadMoreStatesCombinedZero<GetPostersDataModel.ResponseItem>(viewModelScope, gallerySettings) {
         override fun refresh() = refresh { posterRepo.getPostersOfUserByUid(0) }
         override fun loadMore() = loadMore { posterRepo.getPostersOfUserByUid(0, it) }
     }

--- a/features/mine/src/main/java/cn/bit101/android/features/mine/MineViewModel.kt
+++ b/features/mine/src/main/java/cn/bit101/android/features/mine/MineViewModel.kt
@@ -21,27 +21,41 @@ internal class MineViewModel @Inject constructor(
     private val userRepo: UserRepo,
     private val posterRepo: PosterRepo,
     private val messageRepo: MessageRepo,
-    private val gallerySettings: GallerySettings,
+    gallerySettings: GallerySettings,
 ) : ViewModel() {
     val userInfoStateLiveData = MutableLiveData<SimpleDataState<GetUserInfoDataModel.Response>?>(null)
 
     val messageCountStateLiveData = MutableLiveData<SimpleDataState<Int>?>(null)
 
-    private val _followingState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope, gallerySettings) {
-        override fun refresh() = refresh { userRepo.getFollowings() }
-        override fun loadMore() = loadMore { userRepo.getFollowings(it.toInt()) }
+    private val newLoadMode = gallerySettings.hideBotPoster.flow
+
+    private val _followingState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope) {
+        override fun refresh() = refresh(
+            newLoadMode,
+            refresh = { userRepo.getFollowings() },
+            loadMore = { userRepo.getFollowings(it.toInt()) }
+        )
+        override fun loadMore() = loadMore(newLoadMode) { userRepo.getFollowings(it.toInt()) }
     }
     val followingStateExports = _followingState.export()
 
-    private val _followerState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope, gallerySettings) {
-        override fun refresh() = refresh { userRepo.getFollowers() }
-        override fun loadMore() = loadMore { userRepo.getFollowers(it.toInt()) }
+    private val _followerState = object : RefreshAndLoadMoreStatesCombinedZero<User>(viewModelScope) {
+        override fun refresh() = refresh(
+            newLoadMode,
+            refresh = { userRepo.getFollowers() },
+            loadMore = { userRepo.getFollowers(it.toInt()) }
+        )
+        override fun loadMore() = loadMore(newLoadMode) { userRepo.getFollowers(it.toInt()) }
     }
     val followerStateExports = _followerState.export()
 
-    private val _postersState = object : RefreshAndLoadMoreStatesCombinedZero<GetPostersDataModel.ResponseItem>(viewModelScope, gallerySettings) {
-        override fun refresh() = refresh { posterRepo.getPostersOfUserByUid(0) }
-        override fun loadMore() = loadMore { posterRepo.getPostersOfUserByUid(0, it) }
+    private val _postersState = object : RefreshAndLoadMoreStatesCombinedZero<GetPostersDataModel.ResponseItem>(viewModelScope) {
+        override fun refresh() = refresh(
+            newLoadMode,
+            refresh = { posterRepo.getPostersOfUserByUid(0) },
+            loadMore = { posterRepo.getPostersOfUserByUid(0, it) }
+        )
+        override fun loadMore() = loadMore(newLoadMode) { posterRepo.getPostersOfUserByUid(0, it) }
     }
     val postersStateExports = _postersState.export()
 

--- a/features/poster/src/main/java/cn/bit101/android/features/poster/ImageDownloader.kt
+++ b/features/poster/src/main/java/cn/bit101/android/features/poster/ImageDownloader.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import androidx.lifecycle.viewModelScope
 import cn.bit101.android.features.common.MainController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,23 +14,43 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 
 class ImageDownloader {
-    private val client = OkHttpClient.Builder().build()
-    private val contentValuesNormal = ContentValues().apply {
-        put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/BIT101/")
-            put(MediaStore.Images.Media.IS_PENDING, 1)
-        }
-    }
+    private val client = OkHttpClient
+        .Builder()
+        .build()
 
-    fun downloadAndAddImage(url: String, ctx: Context, mainController: MainController, callback: ()->Unit)
-    = CoroutineScope(Dispatchers.Main).launch {
+    private val contentValuesNormal = ContentValues()
+        .apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/BIT101/")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        }
+
+    fun downloadAndAddImage(
+        url: String,
+        ctx: Context,
+        mainController: MainController,
+        callback: ()->Unit
+    ) = CoroutineScope(Dispatchers.IO).launch {
         try {
             async(Dispatchers.IO) {
-                val request = Request.Builder().url(url).build()
+                val request = Request
+                    .Builder()
+                    .url(url)
+                    .build()
 
                 val contentValues = contentValuesNormal.apply {
-                    put(MediaStore.Images.Media.DISPLAY_NAME, "BIT101_IMG_${System.currentTimeMillis()}.jpg")
+                    val extensionName = url.substringAfterLast('.')
+
+                    // 总感觉 101 上的图片都是 .jpeg, 所以这里似乎没必要
+                    // 但还是先这么写着了
+                    put(MediaStore.Images.Media.MIME_TYPE, when(extensionName) {
+                        "png" -> "image/png"
+                        "gif" -> "image/gif"
+                        else -> "image/jpeg"
+                    })
+
+                    put(MediaStore.Images.Media.DISPLAY_NAME, "BIT101_IMG_${System.currentTimeMillis()}.$extensionName")
                 }
 
                 val resolver = ctx.contentResolver
@@ -52,7 +71,7 @@ class ImageDownloader {
             }.await()
             mainController.snackbar("图片已保存到相册!")
             callback()
-        }catch (e:Exception){
+        } catch (e:Exception) {
             mainController.snackbar("图片保存失败Orz")
         }
     }

--- a/features/poster/src/main/java/cn/bit101/android/features/poster/ImageDownloader.kt
+++ b/features/poster/src/main/java/cn/bit101/android/features/poster/ImageDownloader.kt
@@ -1,0 +1,59 @@
+package cn.bit101.android.features.poster
+
+import android.content.ContentValues
+import android.content.Context
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.lifecycle.viewModelScope
+import cn.bit101.android.features.common.MainController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+class ImageDownloader {
+    private val client = OkHttpClient.Builder().build()
+    private val contentValuesNormal = ContentValues().apply {
+        put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/BIT101/")
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+    }
+
+    fun downloadAndAddImage(url: String, ctx: Context, mainController: MainController, callback: ()->Unit)
+    = CoroutineScope(Dispatchers.Main).launch {
+        try {
+            async(Dispatchers.IO) {
+                val request = Request.Builder().url(url).build()
+
+                val contentValues = contentValuesNormal.apply {
+                    put(MediaStore.Images.Media.DISPLAY_NAME, "BIT101_IMG_${System.currentTimeMillis()}.jpg")
+                }
+
+                val resolver = ctx.contentResolver
+                val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+                    ?: throw Exception("Failed to create MediaStore entry")
+
+                resolver.openOutputStream(uri)?.use { outputStream ->
+                    client.newCall(request).execute().body?.byteStream()?.use { inputStream ->
+                        inputStream.copyTo(outputStream)
+
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            contentValues.clear()
+                            contentValues.put(MediaStore.Images.Media.IS_PENDING, 0)
+                            resolver.update(uri, contentValues, null, null)
+                        }
+                    }
+                }
+            }.await()
+            mainController.snackbar("图片已保存到相册!")
+            callback()
+        }catch (e:Exception){
+            mainController.snackbar("图片保存失败Orz")
+        }
+    }
+}

--- a/features/poster/src/main/java/cn/bit101/android/features/poster/PosterViewModel.kt
+++ b/features/poster/src/main/java/cn/bit101/android/features/poster/PosterViewModel.kt
@@ -3,6 +3,7 @@ package cn.bit101.android.features.poster
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cn.bit101.android.config.setting.base.GallerySettings
 import cn.bit101.android.data.repo.base.PosterRepo
 import cn.bit101.android.data.repo.base.ReactionRepo
 import cn.bit101.android.data.repo.base.UploadRepo
@@ -86,6 +87,7 @@ internal class PosterViewModel @Inject constructor(
     private val posterRepo: PosterRepo,
     private val reactionRepo: ReactionRepo,
     private val uploadRepo: UploadRepo,
+    private val gallerySettings: GallerySettings,
 ) : ViewModel() {
     private val _getPosterStateFlow = MutableStateFlow<SimpleDataState<GetPosterDataModel.Response>?>(null)
     val getPosterStateFlow = _getPosterStateFlow.asStateFlow()
@@ -97,7 +99,7 @@ internal class PosterViewModel @Inject constructor(
         _commentsOrderFlow.value = order
     }
 
-    private val _commentState = object : RefreshAndLoadMoreStatesCombinedOne<Long, Comment>(viewModelScope) {
+    private val _commentState = object : RefreshAndLoadMoreStatesCombinedOne<Long, Comment>(viewModelScope, gallerySettings) {
         override fun refresh(data: Long) = refresh { posterRepo.getCommentsById(data, null, commentsOrderFlow.value.value) }
         override fun loadMore(data: Long) = loadMore { posterRepo.getCommentsById(data, it.toInt(), commentsOrderFlow.value.value) }
     }
@@ -110,7 +112,7 @@ internal class PosterViewModel @Inject constructor(
         _subCommentsOrderFlow.value = order
     }
 
-    private val _subCommentState = object : RefreshAndLoadMoreStatesCombinedOne<Long, Comment>(viewModelScope) {
+    private val _subCommentState = object : RefreshAndLoadMoreStatesCombinedOne<Long, Comment>(viewModelScope, gallerySettings) {
         override fun refresh(data: Long) = refresh { posterRepo.getCommentsOfCommentById(data, null, subCommentsOrderFlow.value.value) }
         override fun loadMore(data: Long) = loadMore { posterRepo.getCommentsOfCommentById(data, it.toInt(), subCommentsOrderFlow.value.value) }
     }

--- a/features/schedule/src/main/java/cn/bit101/android/features/schedule/ScheduleScreen.kt
+++ b/features/schedule/src/main/java/cn/bit101/android/features/schedule/ScheduleScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import cn.bit101.android.features.common.MainController
+import cn.bit101.android.features.schedule.classroom.FreeClassroomSearch
 import cn.bit101.android.features.schedule.component.TabPager
 import cn.bit101.android.features.schedule.component.TabPagerItem
 import cn.bit101.android.features.schedule.course.CourseSchedule
@@ -17,6 +18,8 @@ fun ScheduleScreen(mainController: MainController) {
         CourseSchedule(mainController, it)
     }, TabPagerItem("DDL") {
         DDLSchedule(mainController, it)
+    }, TabPagerItem("空教室") {
+        FreeClassroomSearch(mainController, it)
     })
 
     Scaffold {

--- a/features/schedule/src/main/java/cn/bit101/android/features/schedule/classroom/FreeClassroomSearch.kt
+++ b/features/schedule/src/main/java/cn/bit101/android/features/schedule/classroom/FreeClassroomSearch.kt
@@ -1,0 +1,469 @@
+package cn.bit101.android.features.schedule.classroom
+
+import androidx.compose.animation.*
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowRight
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.rounded.ArrowUpward
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import cn.bit101.android.features.common.MainController
+import cn.bit101.android.features.common.helper.SimpleDataState
+import cn.bit101.android.features.common.helper.SimpleState
+import cn.bit101.android.features.common.nav.NavDest
+import cn.bit101.android.features.schedule.classroom.FreeClassroomSearchViewModel.ClassroomBusyData
+import cn.bit101.api.model.common.BuildingInfo
+import kotlinx.coroutines.launch
+import java.time.LocalTime
+import java.util.*
+
+@Composable
+internal fun GetCurrentTime(): LocalTime {
+    var currentTime by remember { mutableStateOf(LocalTime.now()) }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    class UpdateTask : TimerTask() {
+        override fun run() {
+            currentTime = LocalTime.now()
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val timer = Timer()
+
+        var updateTime = UpdateTask()
+
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> {
+                    updateTime.run()    // 考虑到用户可能离开了比较久 (或者出去改时间了 XD), 直接更新一次
+                    timer.schedule(updateTime, (60 - LocalTime.now().second)  * 1000L, 60 * 1000)
+                }
+                Lifecycle.Event.ON_PAUSE -> {
+                    updateTime.cancel()
+                    updateTime = UpdateTask()   // 取消后的任务不能再次使用, 只能新建一次
+                }
+                else -> {}
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            timer.cancel()
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    return currentTime
+}
+
+// 从 DDL 那拾来的
+private fun mixColor(color1: Color, color2: Color, ratio: Float): Color {
+    return Color(
+        (color1.red * ratio + color2.red * (1 - ratio)),
+        (color1.green * ratio + color2.green * (1 - ratio)),
+        (color1.blue * ratio + color2.blue * (1 - ratio))
+    )
+}
+
+private fun formatSecondToString(second: Int): String {
+    return when (second) {
+        in 0..<60 -> "< 1 分钟"
+        in 60..<60 * 60 -> "${second / 60} 分钟"
+        in 60 * 60..Int.MAX_VALUE ->
+            "${
+                second / 60 / 60
+            } 小时${
+                if((second / 60) % 60 != 0)
+                    " ${(second / 60) % 60} 分钟"
+                else
+                    ""
+            }"
+        else -> "-${formatSecondToString(-second)}" // 按理来说不会发生
+    }
+}
+
+@Composable
+internal fun ClassroomList(
+    currentClassrooms: List<ClassroomBusyData>,
+    nowTime: LocalTime,
+    isFreeNow: (ClassroomBusyData) -> Boolean
+) {
+    currentClassrooms
+        .forEach { item ->
+            val restSeconds = (item.nextBusyTime.toSecondOfDay() - nowTime.toSecondOfDay())
+
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp, 5.dp)
+                    .clip(MaterialTheme.shapes.medium),
+                color =
+                if(isFreeNow(item))
+                    MaterialTheme.colorScheme.secondaryContainer
+                else
+                    mixColor(
+                        MaterialTheme.colorScheme.errorContainer,
+                        MaterialTheme.colorScheme.secondaryContainer,
+                        0.5f
+                    ),
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(15.dp, 15.dp, 5.dp, 15.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                    ) {
+                        Text(
+                            text = item.classroom.classroomName,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Text(
+                            text = "空闲时段: ${item.prettyFreeTimes}",
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
+                    Column(
+                        horizontalAlignment = Alignment.End,
+                    ){
+                        Text(
+                            style = MaterialTheme.typography.bodyMedium,
+                            text = when (item.nextBusyTime) {
+                                LocalTime.MAX -> "空闲到明天"
+                                else -> {
+                                    if(restSeconds > 0)
+                                        "还会空闲 ${formatSecondToString(restSeconds)}"
+                                    else if(item.nextFreeTime!=null)
+                                        "${
+                                            formatSecondToString(
+                                                item.nextFreeTime.toSecondOfDay() - nowTime.toSecondOfDay()
+                                            )
+                                        } 后空闲"
+                                    else
+                                        "使用中"
+                                }
+                            }
+                        )
+                        if(item.nextBusyTime!=LocalTime.MAX)
+                            Text(
+                                style = MaterialTheme.typography.bodySmall,
+                                text =
+                                if(restSeconds > 0)
+                                    "(直到 ${item.nextBusyTime})"
+                                else if(item.nextFreeTime!=null)
+                                    "(${item.nextFreeTime})"
+                                else ""
+                            )
+                    }
+                }
+            }
+        }
+}
+
+@Composable
+internal fun BuildingItem(
+    buildingInfo: BuildingInfo,
+    expanded: Boolean,
+    onSwitchActive: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(10.dp, 5.dp)
+            .clip(MaterialTheme.shapes.medium)
+            .clickable { onSwitchActive() },
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shape = MaterialTheme.shapes.medium
+    ) {
+        val arrowRotateDegrees: Float by animateFloatAsState(if (expanded) 90f else 0f)
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(15.dp, 15.dp, 5.dp, 15.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+            ) {
+                Text(
+                    text = buildingInfo.buildingName,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text(
+                    text = buildingInfo.campusName,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Outlined.ArrowRight,
+                contentDescription = null,
+                modifier = Modifier
+                    .scale(1.25f)
+                    .padding(horizontal = 5.dp)
+                    .rotate(arrowRotateDegrees)
+            )
+        }
+    }
+}
+
+@Composable
+internal fun LoadingTip(
+    tipText: String,
+) {
+    Text(
+        text = tipText,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(10.dp, 5.dp)
+            .clip(MaterialTheme.shapes.medium)
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(10.dp, 5.dp),
+        textAlign = TextAlign.Center,
+        color = MaterialTheme.colorScheme.onSecondaryContainer,
+    )
+    LinearProgressIndicator(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp, 5.dp)
+    )
+}
+
+@Composable
+internal fun FreeClassroomSearch(
+    mainController: MainController,
+    active: Boolean,
+    vm: FreeClassroomSearchViewModel = hiltViewModel()
+) {
+    val getBuildingTypeStatus by vm.getBuildingTypeStatusLiveData.observeAsState()
+
+    val allBuildings = (getBuildingTypeStatus as? SimpleDataState.Success)?.data ?: emptyList()
+
+    val currentCampus by vm.nowCampusFlow.collectAsState(initial = null)
+
+    val getClassroomStatusMap = vm.getClassroomsStatesMap
+
+    val currentClassroomData = vm.classroomDataMap
+
+    val hideBusyClassroom = vm.hideBusyClassroomFlow.collectAsState(initial = false)
+
+    val freeMinutesThreshold by vm.freeMinutesThresholdFlow.collectAsState(initial = null)
+
+    val selectedIndices = vm.selectedIndices
+
+    val listState = rememberLazyListState()
+
+    val coroutineScope = rememberCoroutineScope()
+
+    var noExitAnimation by remember { mutableStateOf(false) }
+    // 非常 dirty 的解决方式, 但好歹是做到了在切换校区时不显示动画地自动折叠所有项
+    var lastCampus by rememberSaveable { mutableStateOf(currentCampus) }
+    LaunchedEffect(currentCampus) {
+        // nowCampus 不可能为空, 所以为 null 的情况只能是 initial, 此时不用管
+        if(currentCampus != null && currentCampus != lastCampus) {
+            // 否则说明校区发生了切换
+            lastCampus = currentCampus
+            noExitAnimation = true
+
+            vm.clearSelectState()
+            listState.scrollToItem(0)
+        }
+    }
+    SideEffect { noExitAnimation = false }
+
+    LaunchedEffect(getBuildingTypeStatus) {
+        if (getBuildingTypeStatus is SimpleDataState.Fail) {
+            mainController.snackbar("拉取教学楼信息失败 Orz...")
+        }
+    }
+
+    val getClassroomLastStatus = vm.getClassroomLastStatusLiveData.value
+    LaunchedEffect(getClassroomLastStatus) {
+        if (getClassroomLastStatus is SimpleState.Fail) {
+            mainController.snackbar("拉取教室信息失败 Orz...")
+        }
+    }
+
+    var lastFreeMinutesThreshold by rememberSaveable{ mutableStateOf(freeMinutesThreshold) }
+    LaunchedEffect(freeMinutesThreshold) {
+        if(freeMinutesThreshold != null && freeMinutesThreshold != lastFreeMinutesThreshold) {
+            lastFreeMinutesThreshold = freeMinutesThreshold
+            vm.refreshAllClassroomInfo()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.BottomEnd
+    ) {
+        val nowTime = GetCurrentTime()
+
+        LazyColumn(modifier = Modifier.fillMaxSize(), state = listState) {
+            if (getBuildingTypeStatus is SimpleDataState.Loading) {
+                item { LoadingTip("正在拉取教学楼列表...") }
+            } else {
+                val validBuildings = allBuildings.filter {
+                    currentCampus == null || currentCampus == "" || it.campusName == currentCampus
+                }
+
+                itemsIndexed(validBuildings) { index, item ->
+                    val nowExpanded by remember { derivedStateOf { selectedIndices.contains(index) } }
+
+                    BuildingItem(
+                        buildingInfo = item,
+                        expanded = nowExpanded,
+                        onSwitchActive = {
+                            if(!nowExpanded) {
+                                vm.loadClassroomInfos(item.buildingIndex)
+                            }
+
+                            vm.switchSelectState(index)
+                        }
+                    )
+
+                    val currentClassrooms =
+                        currentClassroomData[item.buildingIndex]
+                            .orEmpty()
+                            .filter { !hideBusyClassroom.value || vm.isFreeNow(it, nowTime, freeMinutesThreshold ?: 0) }
+
+                    AnimatedVisibility(
+                        visible = nowExpanded,
+                        enter = fadeIn()
+                                + expandVertically(),
+                        exit =
+                        if(noExitAnimation)
+                            ExitTransition.None
+                        else
+                            fadeOut() + shrinkVertically()
+                    ) {
+                        if(getClassroomStatusMap[item.buildingIndex] is SimpleState.Loading) {
+                            LoadingTip("正在获取教室列表...")
+                        } else {
+                            if(currentClassrooms.isEmpty()) {
+                                Text(
+                                    text = "未找到教室 :(",
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(10.dp, 5.dp)
+                                        .clip(MaterialTheme.shapes.medium)
+                                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                                        .padding(10.dp, 5.dp),
+                                    textAlign = TextAlign.Center,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                )
+                            } else {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(start = 25.dp)
+                                )
+                                {
+                                    ClassroomList(
+                                        currentClassrooms = currentClassrooms,
+                                        nowTime = nowTime,
+                                        isFreeNow = { vm.isFreeNow(it, nowTime, freeMinutesThreshold ?: 0) },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 悬浮按钮组
+        val fabSize = 42.dp
+        Column(
+            modifier = Modifier
+                .padding(10.dp, 20.dp)
+        ) {
+            // 从话廊那毛过来的回到顶部按钮
+            val show by remember { derivedStateOf { listState.firstVisibleItemIndex > 0 } }
+            AnimatedVisibility(
+                visible = show,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                FloatingActionButton(
+                    modifier = Modifier
+                        .size(fabSize),
+                    onClick = {
+                        coroutineScope.launch {
+                            listState.animateScrollToItem(0)
+                        }
+                    },
+                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(0.8f),
+                    contentColor = MaterialTheme.colorScheme.primary,
+                    elevation = FloatingActionButtonDefaults.elevation(0.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.ArrowUpward,
+                        contentDescription = "回到顶部"
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(10.dp))
+            // 设置按钮
+            FloatingActionButton(
+                modifier = Modifier
+                    .size(fabSize),
+                onClick = { mainController.navigate(NavDest.Setting("freeClassroom")) },
+                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(0.8f),
+                contentColor = MaterialTheme.colorScheme.primary,
+                elevation = FloatingActionButtonDefaults.elevation(0.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Settings,
+                    contentDescription = "settings",
+                )
+            }
+        }
+    }
+}

--- a/features/schedule/src/main/java/cn/bit101/android/features/schedule/classroom/FreeClassroomSearchViewModel.kt
+++ b/features/schedule/src/main/java/cn/bit101/android/features/schedule/classroom/FreeClassroomSearchViewModel.kt
@@ -197,7 +197,7 @@ internal class FreeClassroomSearchViewModel @Inject constructor(
                             val nowIndex = sortedBusyTimeIndices[findIndex]
                             val nextIndex = sortedBusyTimeIndices[findIndex + 1]
 
-                            if(timeTable[nowIndex].startTime >= LocalTime.now()
+                            if(timeTable[nowIndex].endTime >= LocalTime.now()
                                 && timeTable[nextIndex].startTime.toSecondOfDay()
                                 - timeTable[nowIndex].endTime.toSecondOfDay()
                                 > settingData.freeMinutesThreshold.get() * 60) {
@@ -232,7 +232,8 @@ internal class FreeClassroomSearchViewModel @Inject constructor(
                 )
             }
 
-            classroomDataMap[buildingId] = classroomDataCache[buildingId]!!.data
+            if(classroomDataCache[buildingId]!!.data != classroomDataMap[buildingId])
+                classroomDataMap[buildingId] = classroomDataCache[buildingId]!!.data
 
             getClassroomsStatesMap[buildingId] = SimpleState.Success
             getClassroomLastStatusLiveData.value = SimpleState.Success
@@ -247,6 +248,10 @@ internal class FreeClassroomSearchViewModel @Inject constructor(
         classroomDataCache.forEach { classroomDataCache[it.key] = it.value.copy(cacheValidUntil = LocalDateTime.now()) }
         val tempKeys = classroomDataCache.map { it.key }
         tempKeys.forEach {loadClassroomInfos(it)}
+    }
+    fun refreshClassroomInfoIfInvalid(buildingId:String) {
+        if(classroomDataCache[buildingId]!!.cacheValidUntil < LocalDateTime.now())
+            loadClassroomInfos(buildingId)
     }
 
     fun isFreeNow(classroomBusyData: ClassroomBusyData,

--- a/features/schedule/src/main/java/cn/bit101/android/features/schedule/classroom/FreeClassroomSearchViewModel.kt
+++ b/features/schedule/src/main/java/cn/bit101/android/features/schedule/classroom/FreeClassroomSearchViewModel.kt
@@ -1,0 +1,272 @@
+package cn.bit101.android.features.schedule.classroom
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cn.bit101.android.config.setting.base.CourseScheduleSettings
+import cn.bit101.android.config.setting.base.FreeClassroomSettings
+import cn.bit101.android.config.setting.base.TimeTable
+import cn.bit101.android.config.setting.base.TimeTableItem
+import cn.bit101.android.data.repo.base.FreeClassroomRepo
+import cn.bit101.android.features.common.helper.SimpleDataState
+import cn.bit101.android.features.common.helper.SimpleState
+import cn.bit101.android.features.common.helper.withSimpleDataStateLiveData
+import cn.bit101.api.model.common.BuildingInfo
+import cn.bit101.api.model.common.ClassroomInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import javax.inject.Inject
+
+@HiltViewModel
+internal class FreeClassroomSearchViewModel @Inject constructor(
+    private val freeClassroomRepo: FreeClassroomRepo,
+    private val settingData: FreeClassroomSettings,
+    private val scheduleSettings: CourseScheduleSettings
+) : ViewModel() {
+    val nowCampusFlow = freeClassroomRepo.getCurrentCampus()
+
+    val hideBusyClassroomFlow = settingData.hideBusyClassroom.flow
+
+    val freeMinutesThresholdFlow = settingData.freeMinutesThreshold.flow
+
+    val getBuildingTypeStatusLiveData = MutableLiveData<SimpleDataState<List<BuildingInfo>>?>(null)
+
+    val selectedIndices = mutableStateListOf<Int>()
+
+    data class ClassroomBusyData(
+        val classroom: ClassroomInfo,
+        val prettyFreeTimes: String,
+        val nextBusyTime: LocalTime,
+        val nextFreeTime: LocalTime? = null,    // 只在 busy 时有值, 记录还有多久才会迎来下一个 (长于阈值的) 空闲时间
+    )
+
+    fun loadBuildingTypes() = withSimpleDataStateLiveData(getBuildingTypeStatusLiveData) {
+        freeClassroomRepo.getBuildingInfos()
+    }
+
+    val getClassroomsStatesMap = mutableStateMapOf<String,SimpleState>()
+    val getClassroomLastStatusLiveData = mutableStateOf<SimpleState?>(null)
+
+    internal data class ClassroomDataCache(
+        val data: List<ClassroomBusyData>,
+        val cacheValidUntil: LocalDateTime
+    )
+
+    val classroomDataMap = mutableStateMapOf<String, List<ClassroomBusyData>>()
+    private var classroomDataCache = hashMapOf<String, ClassroomDataCache>()
+
+    // 获取时间表上的下一个时间节点
+    private fun getNextTimeTableTime(timeTable: TimeTable) : LocalTime {
+        val nextTimeTableItem = timeTable
+            .find { it.startTime > LocalTime.now() || it.endTime > LocalTime.now() }
+            ?: TimeTableItem(LocalTime.MAX, LocalTime.MAX)
+
+        return if(nextTimeTableItem.startTime > LocalTime.now())
+            nextTimeTableItem.startTime
+        else
+            nextTimeTableItem.endTime
+    }
+    // 根据非空闲时段获取格式化后的空闲时段字符串, 合并相邻的时段, 并按时间顺序排序
+    private fun getPrettyFreeTimeStr(sortedBusyTimes: List<Int>, timeCount: Int): String {
+        var prettyFreeTime = ""
+
+        val sortedFreeTimes = ((1..timeCount) - sortedBusyTimes.toSet()).toList()
+
+        if (sortedFreeTimes.isNotEmpty()) {
+            var lastGroupIndex = 0
+
+            prettyFreeTime += sortedFreeTimes.first()
+
+            for (i in 1..<sortedFreeTimes.size) {
+                if (sortedFreeTimes[i] - i != sortedFreeTimes[lastGroupIndex] - lastGroupIndex) {
+                    if (i - lastGroupIndex > 1) {
+                        prettyFreeTime += "~${sortedFreeTimes[i - 1]}, ${sortedFreeTimes[i]}"
+                    } else {
+                        prettyFreeTime += ", ${sortedFreeTimes[i]}"
+                    }
+                    lastGroupIndex = i
+                } else if(i == sortedFreeTimes.size - 1) {
+                    // 一个区间的收尾是由下一个区间 / 单个值的开始负责的 (比如 1~3, 7~9 里, 1~3 的那个 3 是由 7 负责输出的)
+                    // 所以最后一个要特殊处理
+                    prettyFreeTime += "~${sortedFreeTimes[i]}"
+                }
+            }
+        } else {
+            prettyFreeTime = "无"
+        }
+
+        return prettyFreeTime
+    }
+    // 获取对应教学楼的全部教室及其空闲情况
+    fun loadClassroomInfos(buildingId:String) = viewModelScope.launch(Dispatchers.IO) {
+        getClassroomsStatesMap[buildingId] = SimpleState.Loading
+        getClassroomLastStatusLiveData.value = SimpleState.Loading
+
+        runCatching{
+            val allClassrooms: List<ClassroomInfo>
+
+            // 从 Web 上拉取下来的值理论上在同一天内都应该相同, 所以缓存失效了也能复用 (不如说本来最需要缓存的就是 Web 请求)
+            if(classroomDataCache.containsKey(buildingId)) {
+                val cacheValidUntil = classroomDataCache[buildingId]!!.cacheValidUntil
+
+                if(cacheValidUntil < LocalDateTime.now()) {
+                    // 换日期了就没办法了
+                    if(cacheValidUntil.toLocalDate() != LocalDate.now()) {
+                        allClassrooms = freeClassroomRepo.getClassroomInfos(buildingId = buildingId)
+                    } else {
+                        allClassrooms = classroomDataCache[buildingId]!!.data.map { it.classroom }
+                    }
+                    classroomDataCache.remove(buildingId)
+                }
+                else {
+                    allClassrooms = emptyList()     // 这个情况下用不到 allClassrooms, 随便给个值就行
+                }
+            } else {
+                allClassrooms = freeClassroomRepo.getClassroomInfos(buildingId = buildingId)
+            }
+
+            if(!classroomDataCache.containsKey(buildingId)) {
+                classroomDataMap.remove(buildingId)
+
+                val timeTable = scheduleSettings.timeTable.get()
+
+                // timeTable 中下一节课对应的下标
+                var nextClassIndex = 0
+
+                if (LocalTime.now() < timeTable.first().startTime)
+                    nextClassIndex = 0
+                else if (LocalTime.now() > timeTable.last().endTime)
+                    nextClassIndex = timeTable.size
+                else {
+                    for (i in timeTable.indices.reversed()) {
+                        if (LocalTime.now() >= timeTable[i].startTime) {
+                            nextClassIndex = i + 1
+                            break
+                        }
+                    }
+                }
+
+                val ret = allClassrooms.map { classroom ->
+                    val sortedBusyTimes =
+                        classroom.busyTimeStr
+                            ?.split(',')
+                            .orEmpty()
+                            .map { it.toInt() }
+                            .sorted()
+
+                    val nextBusyTime: LocalTime
+
+                    // 先计算下一个开始不空闲的时间, 为 LocalTime.MIN 说明在计算时就已经不空闲了, 为 LocalTime.MAX 则说明直到今天结束都保持空闲
+                    if(nextClassIndex < timeTable.size) {
+                        val nextBusyTimeIndex = sortedBusyTimes.find { it - 1 >= nextClassIndex }?.minus(1)
+
+                        nextBusyTime =
+                            if (nextBusyTimeIndex == null)   // 没找到说明后面没课了
+                                LocalTime.MAX
+                            else
+                                if (sortedBusyTimes.contains(nextBusyTimeIndex)
+                                    && timeTable[nextBusyTimeIndex - 1].endTime >= LocalTime.now()
+                                )     // 当前正在上课
+                                    LocalTime.MIN
+                                else
+                                    timeTable[nextBusyTimeIndex].startTime
+                    } else {
+                        nextBusyTime =
+                            if(sortedBusyTimes.isNotEmpty() && timeTable[sortedBusyTimes.last() - 1].endTime >= LocalTime.now())
+                                LocalTime.MIN
+                            else
+                                LocalTime.MAX
+                    }
+
+                    // 再 (在当前不空闲的情况下) 计算下一个恢复空闲的时间
+                    // 会考虑阈值
+                    var nextFreeTime: LocalTime? = null
+
+                    if(nextBusyTime == LocalTime.MIN) {
+                        var findIndex = 0
+                        val sortedBusyTimeIndices = sortedBusyTimes.map{ it - 1 }
+
+                        while(findIndex < sortedBusyTimeIndices.size - 1) {
+                            val nowIndex = sortedBusyTimeIndices[findIndex]
+                            val nextIndex = sortedBusyTimeIndices[findIndex + 1]
+
+                            if(timeTable[nowIndex].startTime >= LocalTime.now()
+                                && timeTable[nextIndex].startTime.toSecondOfDay()
+                                - timeTable[nowIndex].endTime.toSecondOfDay()
+                                > settingData.freeMinutesThreshold.get() * 60) {
+                                nextFreeTime = timeTable[nowIndex].endTime
+                                break
+                            }
+                            findIndex++
+                        }
+                        // 无论如何, 所有课上完后教室一定会空闲下来
+                        if(nextFreeTime == null)
+                            nextFreeTime = timeTable[sortedBusyTimeIndices.last()].endTime
+                    }
+
+                    ClassroomBusyData(
+                        classroom = classroom,
+                        prettyFreeTimes = getPrettyFreeTimeStr(sortedBusyTimes,timeTable.size),
+                        nextBusyTime = nextBusyTime,
+                        nextFreeTime = nextFreeTime,
+                    )
+                }.sortedWith(
+                    compareByDescending<ClassroomBusyData> {
+                        if(it.nextBusyTime == LocalTime.MIN)
+                            -it.nextFreeTime!!.toSecondOfDay()  // 负数既可以反转排序顺序, 也能保证目前空闲的教室一定排在目前不空闲的前面
+                        else
+                            it.nextBusyTime.toSecondOfDay()
+                    }.thenBy { it.classroom.classroomName }
+                )
+
+                classroomDataCache[buildingId] = ClassroomDataCache(
+                    data = ret,
+                    cacheValidUntil = getNextTimeTableTime(timeTable).atDate(LocalDate.now())
+                )
+            }
+
+            classroomDataMap[buildingId] = classroomDataCache[buildingId]!!.data
+
+            getClassroomsStatesMap[buildingId] = SimpleState.Success
+            getClassroomLastStatusLiveData.value = SimpleState.Success
+        }.onFailure {
+            it.printStackTrace()
+
+            getClassroomsStatesMap[buildingId] = SimpleState.Fail
+            getClassroomLastStatusLiveData.value = SimpleState.Fail
+        }
+    }
+    fun refreshAllClassroomInfo() {
+        classroomDataCache.forEach { classroomDataCache[it.key] = it.value.copy(cacheValidUntil = LocalDateTime.now()) }
+        val tempKeys = classroomDataCache.map { it.key }
+        tempKeys.forEach {loadClassroomInfos(it)}
+    }
+
+    fun isFreeNow(classroomBusyData: ClassroomBusyData,
+                  nowTime: LocalTime,
+                  freeMinutesThreshold: Long) : Boolean {
+        return classroomBusyData.nextBusyTime == LocalTime.MAX
+                || classroomBusyData.nextBusyTime.toSecondOfDay() >= nowTime.toSecondOfDay() + freeMinutesThreshold * 60
+    }
+
+    fun switchSelectState(index:Int){
+        if(selectedIndices.contains(index))
+            selectedIndices.remove(index)
+        else
+            selectedIndices.add(index)
+    }
+    fun clearSelectState() {
+        selectedIndices.clear()
+    }
+
+    init {
+        loadBuildingTypes()
+    }
+}

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/SettingIndexPage.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/SettingIndexPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Chat
 import androidx.compose.material.icons.automirrored.outlined.EventNote
+import androidx.compose.material.icons.automirrored.outlined.NotListedLocation
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.ColorLens
 import androidx.compose.material.icons.outlined.Dashboard
@@ -60,9 +61,15 @@ internal fun SettingIndexPage(
         ),
         SettingItemData.IndexCard(
             title = "话廊设置",
-            subTitle = "设置是否显示某些 Poster",
+            subTitle = "话廊数据及显示方式",
             icon = Icons.AutoMirrored.Outlined.Chat,
             onClick = { navController.navigate("gallery") },
+        ),
+        SettingItemData.IndexCard(
+            title = "空教室查询设置",
+            subTitle = "所在校区及显示方式",
+            icon = Icons.AutoMirrored.Outlined.NotListedLocation,
+            onClick = { navController.navigate("freeClassroom") },
         ),
         SettingItemData.IndexCard(
             title = "关于",

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/SettingIndexPage.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/SettingIndexPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Chat
 import androidx.compose.material.icons.automirrored.outlined.EventNote
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.ColorLens
@@ -56,6 +57,12 @@ internal fun SettingIndexPage(
             subTitle = "日程数据及显示方式",
             icon = Icons.AutoMirrored.Outlined.EventNote,
             onClick = { navController.navigate("ddl") },
+        ),
+        SettingItemData.IndexCard(
+            title = "话廊设置",
+            subTitle = "设置是否显示某些 Poster",
+            icon = Icons.AutoMirrored.Outlined.Chat,
+            onClick = { navController.navigate("gallery") },
         ),
         SettingItemData.IndexCard(
             title = "关于",

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/SettingScreen.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/SettingScreen.kt
@@ -14,6 +14,7 @@ import cn.bit101.android.features.common.nav.delayRemainTransition
 import cn.bit101.android.features.common.nav.enterTransition
 import cn.bit101.android.features.common.nav.exitTransition
 import cn.bit101.android.features.setting.component.SettingPage
+import cn.bit101.android.features.setting.page.*
 import cn.bit101.android.features.setting.page.AboutPage
 import cn.bit101.android.features.setting.page.AccountPage
 import cn.bit101.android.features.setting.page.CalendarSettingPage
@@ -93,6 +94,16 @@ fun SettingScreen(
                 navController = navController,
             ) {
                 CalendarSettingPage(onSnackBar = onSnackBar)
+            }
+        }
+
+        composable("gallery") {
+            SettingPage(
+                mainController = mainController,
+                title = "话廊设置",
+                navController = navController,
+            ) {
+                GallerySettingPage()
             }
         }
 

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/SettingScreen.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/SettingScreen.kt
@@ -126,5 +126,15 @@ fun SettingScreen(
                 DDLSettingPage(onSnackBar = onSnackBar)
             }
         }
+
+        composable("freeClassroom") {
+            SettingPage(
+                mainController = mainController,
+                title = "空教室查询设置",
+                navController = navController,
+            ) {
+                FreeClassroomSettingPage(onSnackBar = onSnackBar)
+            }
+        }
     }
 }

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/component/SettingItemCard.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/component/SettingItemCard.kt
@@ -235,7 +235,7 @@ internal fun SettingItem(data: SettingItemData) {
             onClick = { data.onClick(!data.checked) },
             enabled = data.enable,
             suffix = {
-                Switch(checked = data.checked, onCheckedChange = data.onClick)
+                Switch(checked = data.checked, onCheckedChange = data.onClick, enabled = data.enable)
             }
         )
     }

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/page/FreeClassroomSettingPage.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/page/FreeClassroomSettingPage.kt
@@ -1,0 +1,260 @@
+package cn.bit101.android.features.setting.page
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import cn.bit101.android.features.common.helper.SimpleDataState
+import cn.bit101.android.features.common.helper.SimpleState
+import cn.bit101.android.features.setting.component.SettingItemData
+import cn.bit101.android.features.setting.component.SettingsColumn
+import cn.bit101.android.features.setting.component.SettingsGroup
+import cn.bit101.android.features.setting.viewmodel.FreeClassroomSettingData
+import cn.bit101.android.features.setting.viewmodel.FreeClassroomViewModel
+
+@Composable
+internal fun CampusSelectDialog(
+    campusList: List<String>,
+    campusSelect: String,
+    loading: Boolean,
+
+    onSetCampus: (String) -> Unit,
+    onDismiss: () -> Unit,
+){
+    val selectedOption = if(campusList.contains(campusSelect)) campusSelect
+    else campusList.firstOrNull() ?: ""
+
+    AlertDialog(
+        modifier = Modifier.fillMaxHeight(0.9f),
+        onDismissRequest = onDismiss,
+        title = { Text(text = "切换校区") },
+        text = {
+            if(loading){
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }else{
+                val scrollState = rememberScrollState()
+                Column(
+                    Modifier
+                        .fillMaxSize()
+                        .selectableGroup()
+                        .verticalScroll(scrollState)
+                ) {
+                    campusList.forEach { campus ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(MaterialTheme.shapes.medium)
+                                .selectable(
+                                    selected = (campus == selectedOption),
+                                    onClick = {
+                                        onSetCampus(campus)
+                                        onDismiss()
+                                    },
+                                    role = Role.RadioButton
+                                )
+                                .padding(10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = (campus == selectedOption),
+                                onClick = null
+                            )
+                            Text(
+                                text = campus,
+                                modifier = Modifier.padding(start = 10.dp),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+    )
+}
+
+// 输入数字对话框 (也是从 DDL 那边 copy 来的)
+@Composable
+private fun InputNumberDialog(
+    title: String,
+    text: String,
+    initValue: Int,
+    onChange: (Int) -> Unit,
+    onDismiss: () -> Unit,
+    onSnackBar: (String) -> Unit,
+) {
+    var editValue by remember { mutableStateOf(TextFieldValue(initValue.toString())) }
+    var errorMessage by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = title)
+        },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(modifier = Modifier.height(5.dp))
+                OutlinedTextField(
+                    value = editValue,
+                    onValueChange = { editValue = it },
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+                Spacer(modifier = Modifier.height(5.dp))
+                Text(
+                    text = errorMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (editValue.text.toIntOrNull() != null && editValue.text.toInt() >= 0) {
+                        onChange(editValue.text.toInt())
+                        onSnackBar("设置成功OvO")
+                        onDismiss()
+                    } else {
+                        errorMessage = "格式校验失败Orz"
+                    }
+                }
+            ) {
+                Text("确定")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("取消")
+            }
+        }
+    )
+}
+
+@Composable
+private fun FreeClassroomSettingPageContent(
+    settingData: FreeClassroomSettingData,
+
+    onOpenEditCampusDialog: () -> Unit,
+    onOpenFreeMinutesThresholdInputDialog: () -> Unit,
+
+    onSettingChange: (FreeClassroomSettingData) -> Unit,
+) {
+    val hideSettings = listOf(
+        SettingItemData.Button(
+            title = "当前校区",
+            text = settingData.currentCampus,
+            onClick = onOpenEditCampusDialog,
+        ),
+        SettingItemData.Switch(
+            title = "隐藏当前不空闲的教室",
+            onClick = { onSettingChange(settingData.copy(hideBusyClassroom = it)) },
+            checked = settingData.hideBusyClassroom,
+        ),
+        SettingItemData.Button(
+            title = "空闲时段阈值",
+            subTitle = "不大于此值的空闲时段将被忽略",
+            text = "${settingData.freeMinutesThreshold} 分钟",
+            onClick = onOpenFreeMinutesThresholdInputDialog,
+        ),
+    )
+
+    SettingsColumn {
+        SettingsGroup(
+            title = "空教室查询设置",
+            items = hideSettings
+        )
+    }
+}
+
+@Composable
+internal fun FreeClassroomSettingPage(
+    onSnackBar: (String) -> Unit,
+) {
+    val vm: FreeClassroomViewModel=hiltViewModel()
+
+    val settingData by vm.settingDataFlow.collectAsState(initial = FreeClassroomSettingData.default)
+
+    val changeSettingStatus by vm.changeSettingStatusLiveData.observeAsState()
+
+    val getBuildingTypeStatus by vm.getBuildingTypeStatusLiveData.observeAsState()
+
+    var showCampusSelectDialog by rememberSaveable { mutableStateOf(false) }
+    var showFreeMinutesThresholdInputDialog by rememberSaveable { mutableStateOf(false) }
+
+    DisposableEffect(changeSettingStatus){
+        if(changeSettingStatus is SimpleState.Success){
+            onSnackBar("设置成功")
+        } else if(changeSettingStatus is SimpleState.Fail) {
+            onSnackBar("设置失败")
+        }
+        onDispose {}
+    }
+
+    if (showCampusSelectDialog) {
+        LaunchedEffect(getBuildingTypeStatus){
+            if(getBuildingTypeStatus is SimpleDataState.Fail || getBuildingTypeStatus==null){
+                vm.loadBuildingTypes()
+            }
+        }
+
+        val campusList=(getBuildingTypeStatus as? SimpleDataState.Success)?.data ?: emptyList()
+
+        CampusSelectDialog(
+            campusList = campusList,
+            campusSelect = settingData.currentCampus,
+            loading = getBuildingTypeStatus is SimpleDataState.Loading,
+
+            onSetCampus = { campus ->
+                vm.setCampus(campus)
+                showCampusSelectDialog = false
+            },
+            onDismiss = { showCampusSelectDialog = false }
+        )
+    }
+
+    if (showFreeMinutesThresholdInputDialog) {
+        InputNumberDialog(
+            title = "空闲时段阈值",
+            text = "不大于此值的空闲时段将被忽略 (单位: 分钟)",
+            initValue = settingData.freeMinutesThreshold.toInt(),
+            onChange = { vm.setFreeMinutesThreshold(it.toLong()) },
+            onDismiss = { showFreeMinutesThresholdInputDialog = false },
+            onSnackBar = onSnackBar
+        )
+    }
+
+    FreeClassroomSettingPageContent(
+        settingData = settingData,
+        onOpenEditCampusDialog = { showCampusSelectDialog = true },
+        onOpenFreeMinutesThresholdInputDialog = { showFreeMinutesThresholdInputDialog = true },
+        onSettingChange = vm::setSettingData
+    )
+}

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/page/FreeClassroomSettingPage.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/page/FreeClassroomSettingPage.kt
@@ -189,6 +189,7 @@ private fun FreeClassroomSettingPageContent(
     SettingsColumn {
         SettingsGroup(
             title = "空教室查询设置",
+            subTitle = "如果获取失败可以尝试在账号设置中“检查登录状态”哦",
             items = hideSettings
         )
     }

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/page/GallerySettingPage.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/page/GallerySettingPage.kt
@@ -1,0 +1,49 @@
+package cn.bit101.android.features.setting.page
+
+import androidx.compose.runtime.*
+import androidx.hilt.navigation.compose.hiltViewModel
+import cn.bit101.android.features.setting.component.SettingItemData
+import cn.bit101.android.features.setting.component.SettingsColumn
+import cn.bit101.android.features.setting.component.SettingsGroup
+import cn.bit101.android.features.setting.viewmodel.GallerySettingData
+import cn.bit101.android.features.setting.viewmodel.GalleryViewModel
+
+@Composable
+private fun GallerySettingPageContent(
+    settingData: GallerySettingData,
+
+    onSettingChange: (GallerySettingData) -> Unit,
+) {
+    val hideSettings = listOf(
+        SettingItemData.Switch(
+            title = "在话廊中隐藏机器人 Poster",
+            subTitle = "搜索栏、关注列表中的不受影响.\n会导致刷新 / 加载变慢",
+            onClick = { onSettingChange(settingData.copy(hideBotPoster = it)) },
+            checked = settingData.hideBotPoster,
+        ),
+        SettingItemData.Switch(
+            title = "也隐藏搜索栏中的机器人 Poster",
+            subTitle = "未开启隐藏机器人 Poster 时不生效",
+            onClick = { onSettingChange(settingData.copy(hideBotPosterInSearch = it)) },
+            checked = settingData.hideBotPosterInSearch,
+        ),
+    )
+
+    SettingsColumn {
+        SettingsGroup(
+            title = "屏蔽设定",
+            items = if(settingData.hideBotPoster) hideSettings.subList(0,2) else hideSettings.subList(0,1)
+        )
+    }
+}
+
+@Composable
+internal fun GallerySettingPage() {
+    val vm: GalleryViewModel = hiltViewModel()
+
+    val settingData by vm.settingDataFlow.collectAsState(initial = GallerySettingData.default)
+
+    GallerySettingPageContent(
+        settingData = settingData,
+        onSettingChange = vm::setSettingData)
+}

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/page/GallerySettingPage.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/page/GallerySettingPage.kt
@@ -26,13 +26,27 @@ private fun GallerySettingPageContent(
             subTitle = "未开启隐藏机器人 Poster 时不生效",
             onClick = { onSettingChange(settingData.copy(hideBotPosterInSearch = it)) },
             checked = settingData.hideBotPosterInSearch,
+            enable = settingData.hideBotPoster,
+        ),
+    )
+
+    val viewSettings = listOf(
+        SettingItemData.Switch(
+            title = "允许横向滑动",
+            subTitle = "可以横向滑动来切换选项卡, 可能导致误触",
+            onClick = { onSettingChange(settingData.copy(allowHorizontalScroll = it)) },
+            checked = settingData.allowHorizontalScroll,
         ),
     )
 
     SettingsColumn {
         SettingsGroup(
-            title = "屏蔽设定",
-            items = if(settingData.hideBotPoster) hideSettings.subList(0,2) else hideSettings.subList(0,1)
+            title = "屏蔽设置",
+            items = hideSettings
+        )
+        SettingsGroup(
+            title = "浏览设置",
+            items = viewSettings
         )
     }
 }
@@ -45,5 +59,6 @@ internal fun GallerySettingPage() {
 
     GallerySettingPageContent(
         settingData = settingData,
-        onSettingChange = vm::setSettingData)
+        onSettingChange = vm::setSettingData
+    )
 }

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/viewmodel/FreeClassroomViewModel.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/viewmodel/FreeClassroomViewModel.kt
@@ -1,0 +1,61 @@
+package cn.bit101.android.features.setting.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import cn.bit101.android.config.setting.base.FreeClassroomSettings
+import cn.bit101.android.data.repo.base.FreeClassroomRepo
+import cn.bit101.android.features.common.helper.*
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+internal data class FreeClassroomSettingData(
+    val currentCampus: String,
+    val hideBusyClassroom: Boolean,
+    val freeMinutesThreshold: Long,
+) {
+    companion object {
+        val default = FreeClassroomSettingData(
+            currentCampus = "",
+            hideBusyClassroom = true,
+            freeMinutesThreshold = 5L,
+        )
+    }
+}
+
+@HiltViewModel
+internal class FreeClassroomViewModel @Inject constructor(
+    private val freeClassroomSettings: FreeClassroomSettings,
+    private val freeClassroomRepo: FreeClassroomRepo
+) : ViewModel() {
+    val settingDataFlow = combine(
+        freeClassroomSettings.currentCampus.flow,
+    ) { settings ->
+        FreeClassroomSettingData(
+            currentCampus = settings[0],
+            hideBusyClassroom = freeClassroomSettings.hideBusyClassroom.get(),
+            freeMinutesThreshold = freeClassroomSettings.freeMinutesThreshold.get(),
+        )
+    }
+
+    val changeSettingStatusLiveData = MutableLiveData<SimpleState?>(null)
+
+    fun setCampus(campus: String) = withSimpleStateLiveData(changeSettingStatusLiveData) {
+        freeClassroomSettings.currentCampus.set(campus)
+    }
+    fun setFreeMinutesThreshold(freeMinutesThreshold: Long) = withSimpleStateLiveData(changeSettingStatusLiveData) {
+        freeClassroomSettings.freeMinutesThreshold.set(freeMinutesThreshold)
+    }
+
+    fun setSettingData(settingData: FreeClassroomSettingData) = withScope {
+        freeClassroomSettings.currentCampus.set(settingData.currentCampus)
+        freeClassroomSettings.hideBusyClassroom.set(settingData.hideBusyClassroom)
+        freeClassroomSettings.freeMinutesThreshold.set(settingData.freeMinutesThreshold)
+    }
+
+    val getBuildingTypeStatusLiveData = MutableLiveData<SimpleDataState<List<String>>?>(null)
+
+    fun loadBuildingTypes() = withSimpleDataStateLiveData(getBuildingTypeStatusLiveData) {
+        freeClassroomRepo.getBuildingInfos().map{it.campusName}.distinct()
+    }
+}

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/viewmodel/GalleryViewModel.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/viewmodel/GalleryViewModel.kt
@@ -1,0 +1,40 @@
+package cn.bit101.android.features.setting.viewmodel
+
+import androidx.lifecycle.ViewModel
+import cn.bit101.android.config.setting.base.GallerySettings
+import cn.bit101.android.features.common.helper.withScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+internal data class GallerySettingData(
+    val hideBotPoster: Boolean,
+    val hideBotPosterInSearch: Boolean,
+) {
+    companion object {
+        val default = GallerySettingData(
+            hideBotPoster = false,
+            hideBotPosterInSearch = false
+        )
+    }
+}
+
+@HiltViewModel
+internal class GalleryViewModel @Inject constructor(
+    private val gallerySettings: GallerySettings
+) : ViewModel() {
+    val settingDataFlow = combine(
+        gallerySettings.hideBotPoster.flow,
+        gallerySettings.hideBotPosterInSearch.flow
+    ) { settings ->
+        GallerySettingData(
+            hideBotPoster = settings[0],
+            hideBotPosterInSearch = settings[1],
+        )
+    }
+
+    fun setSettingData(settingData: GallerySettingData) = withScope {
+        gallerySettings.hideBotPoster.set(settingData.hideBotPoster)
+        gallerySettings.hideBotPosterInSearch.set(settingData.hideBotPosterInSearch)
+    }
+}

--- a/features/setting/src/main/java/cn/bit101/android/features/setting/viewmodel/GalleryViewModel.kt
+++ b/features/setting/src/main/java/cn/bit101/android/features/setting/viewmodel/GalleryViewModel.kt
@@ -10,11 +10,13 @@ import javax.inject.Inject
 internal data class GallerySettingData(
     val hideBotPoster: Boolean,
     val hideBotPosterInSearch: Boolean,
+    val allowHorizontalScroll: Boolean,
 ) {
     companion object {
         val default = GallerySettingData(
             hideBotPoster = false,
-            hideBotPosterInSearch = false
+            hideBotPosterInSearch = false,
+            allowHorizontalScroll = false
         )
     }
 }
@@ -25,16 +27,19 @@ internal class GalleryViewModel @Inject constructor(
 ) : ViewModel() {
     val settingDataFlow = combine(
         gallerySettings.hideBotPoster.flow,
-        gallerySettings.hideBotPosterInSearch.flow
+        gallerySettings.hideBotPosterInSearch.flow,
+        gallerySettings.allowHorizontalScroll.flow,
     ) { settings ->
         GallerySettingData(
             hideBotPoster = settings[0],
             hideBotPosterInSearch = settings[1],
+            allowHorizontalScroll = settings[2],
         )
     }
 
     fun setSettingData(settingData: GallerySettingData) = withScope {
         gallerySettings.hideBotPoster.set(settingData.hideBotPoster)
         gallerySettings.hideBotPosterInSearch.set(settingData.hideBotPosterInSearch)
+        gallerySettings.allowHorizontalScroll.set(settingData.allowHorizontalScroll)
     }
 }

--- a/features/src/main/java/cn/bit101/android/features/MainApp.kt
+++ b/features/src/main/java/cn/bit101/android/features/MainApp.kt
@@ -5,11 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -102,7 +98,7 @@ internal fun MainApp() {
     }
 
     // 图片保存工具类
-    val imageDownloader = ImageDownloader()
+    val imageDownloader = remember { ImageDownloader() }
 
     NavHost(
         modifier = Modifier.fillMaxSize(),
@@ -166,7 +162,7 @@ internal fun MainApp() {
     ImageHost(
         modifier = Modifier.fillMaxSize(),
         state = mainController.imageHostState,
-        onOpenUrl = {str:String,callback:()->Unit ->
+        onDownloadImage = { str: String, callback: () -> Unit ->
             imageDownloader.downloadAndAddImage(str, ctx, mainController, callback)
         },
     )

--- a/features/src/main/java/cn/bit101/android/features/MainApp.kt
+++ b/features/src/main/java/cn/bit101/android/features/MainApp.kt
@@ -42,6 +42,7 @@ import cn.bit101.android.features.common.utils.ColorUtils
 import cn.bit101.android.features.index.IndexScreen
 import cn.bit101.android.features.login.LoginOrLogoutScreen
 import cn.bit101.android.features.postedit.PostEditScreen
+import cn.bit101.android.features.poster.ImageDownloader
 import cn.bit101.android.features.poster.PosterScreen
 import cn.bit101.android.features.report.ReportScreen
 import cn.bit101.android.features.setting.SettingScreen
@@ -99,6 +100,9 @@ internal fun MainApp() {
     if (autoDetectUpgrade) {
         UpdateDialog()
     }
+
+    // 图片保存工具类
+    val imageDownloader = ImageDownloader()
 
     NavHost(
         modifier = Modifier.fillMaxSize(),
@@ -162,7 +166,9 @@ internal fun MainApp() {
     ImageHost(
         modifier = Modifier.fillMaxSize(),
         state = mainController.imageHostState,
-        onOpenUrl = { mainController.openUrl(it, ctx) },
+        onOpenUrl = {str:String,callback:()->Unit ->
+            imageDownloader.downloadAndAddImage(str, ctx, mainController, callback)
+        },
     )
 
     SnackbarHost(

--- a/features/user/src/main/java/cn/bit101/android/features/user/UserViewModel.kt
+++ b/features/user/src/main/java/cn/bit101/android/features/user/UserViewModel.kt
@@ -3,6 +3,7 @@ package cn.bit101.android.features.user
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cn.bit101.android.config.setting.base.GallerySettings
 import cn.bit101.android.data.repo.base.PosterRepo
 import cn.bit101.android.data.repo.base.UserRepo
 import cn.bit101.android.features.common.helper.RefreshAndLoadMoreStatesCombinedOne
@@ -20,12 +21,13 @@ import javax.inject.Inject
 internal class UserViewModel @Inject constructor(
     private val userRepo: UserRepo,
     private val posterRepo: PosterRepo,
+    private val gallerySettings: GallerySettings
 ) : ViewModel() {
 
     private val _getUserInfoStateFlow = MutableStateFlow<SimpleDataState<GetUserInfoDataModel.Response>?>(null)
     val getUserInfoStateFlow = _getUserInfoStateFlow
 
-    private val _posterState = object : RefreshAndLoadMoreStatesCombinedOne<Long, GetPostersDataModel.ResponseItem>(viewModelScope) {
+    private val _posterState = object : RefreshAndLoadMoreStatesCombinedOne<Long, GetPostersDataModel.ResponseItem>(viewModelScope, gallerySettings) {
         override fun refresh(data: Long) = refresh {
             posterRepo.getPostersOfUserByUid(data)
         }


### PR DESCRIPTION
大致改动: 
1. 在“卷”页面下加了一栏空教室查询, 能查询各个校区的各个教学楼的空教室
    - 支持配置当前校区、是否显示当前不空闲的教室、空闲时段阈值(不大于这个时间间隔的空闲时段会被忽略, 防止识别到课间 5 分钟等情况)
    - 对于当前空闲的教室, 会显示该教室还会空闲多久(以及停止空闲的最后时间点)
    - 对于当前不空闲(但设置为仍然显示)的教室, 会显示该教室在多久后空闲(以及对应时间点)
        - 调整前面的阈值设定, 可以不把短课间算进去 (默认阈值是 5 分钟, 恰好不会计算 5 分钟的小课间)
    - 数据来自 BIT 官方, 理论上获取到的教室空闲情况和 i北理上的一致
    - 课程时间表、当前学期等都是直接使用的课程表设置内的数据
2. 给 APP 自带的“话廊”页面添加了屏蔽机器人功能(可选, 默认关闭)
    - 默认情况下, 即使开启了该功能, 搜索页面、关注列表、以及直接点机器人头像看到的帖子列表都不会受影响
    - 但是, 也可以选择将搜索页面的机器人帖子一并屏蔽.
    - 开启该功能会导致刷新 / 加载更多变慢, 但理论上关闭时几乎不会带来额外的性能开销
3. 给 APP 自带的“话廊”页面添加了左右滑动切换选项卡的功能(可选, 默认关闭). 左右滑动切换选项卡时, 右下角的浮动按钮会保持不动. 同时加了一个“话廊设置”, 能自由调整相关改动
    - 看源代码貌似这个左右切换是被刻意关闭的, 所以有点不确定该不该改. 个人是习惯左右滑的, 虽然确实偶尔会误触.
4. 对于 APP 自带的“话廊”页面(不是“网”下面的话廊页面), 下载图片时, 可以直接保存到手机相册, 而不是在浏览器中打开链接.

主要改了一些自己用起来不舒服, 以及社区里经常提到的一些地方.      
我自己把交 pr 前的仓库 clone 到本地重新编译过, 貌似没什么问题, 所以大概没问题......吧     
(JDK 是 Zulu-17, IDE 是 IDEA 2024.2.4 #IU-242.23726.103)

大一小登, 第一次提 pr, 第一次写 Kotlin, 第一次用 Jetpack Compose , 总之希望没出太大事故. 如果有什么不妥之处请务必告诉我 QwQ...

以及希望 101 越来越好, 一起一辈子 101!